### PR TITLE
WINDUP-2392 Deploy to Insights CI Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ AMQ Web Console
 ## Camel routes
 To enable the `DEBUG` level for logging, please add the environment variable `logging.level.org` (or whatever package you want) with value `DEBUG` to the the `analytics-integration` deployment configuration. 
 # Undeploy
-1. `oc delete all,pvc -l application=migration-analytics -n migration-analytics`
+1. `oc delete all,pvc,secrets -l application=migration-analytics -n migration-analytics`
 
 # References

--- a/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
@@ -133,6 +133,7 @@ public class MainRouteBuilder extends RouteBuilder {
                     }
                 })
                 .unmarshal().json(JsonLibrary.Jackson, FilePersistedNotification.class)
+                .filter(simple("'ma-xavier' == ${body.getCategory}"))
                 .to("direct:download-from-S3");
 
         from("kafka:" + kafkaHost + "?topic={{insights.kafka.validation.topic}}&brokers=" + kafkaHost + "&autoOffsetReset=latest&autoCommitEnable=true")

--- a/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
@@ -131,15 +131,15 @@ public class MainRouteBuilder extends RouteBuilder {
                                 " message :: "+ data + "\n");
                     }
                 })
+                .filter().method(MainRouteBuilder.class, "filterMessages")
                 .unmarshal().json(JsonLibrary.Jackson, FilePersistedNotification.class)
                 .to("direct:download-from-S3");
 
         from("kafka:" + kafkaHost + "?topic={{insights.kafka.validation.topic}}&brokers=" + kafkaHost + "&autoOffsetReset=latest&autoCommitEnable=true")
                 .id("kafka-validation-message")
-                .to("log:INFO?showBody=true&amp;showHeaders=true");
+                .to("log:INFO?showBody=true&showHeaders=true");
 
         from("direct:download-from-S3")
-                .filter().method(MainRouteBuilder.class, "filterMessages")
                 .setHeader("Exchange.HTTP_URI", simple("${body.url}"))
                 .process( exchange -> {
                     FilePersistedNotification filePersistedNotification = exchange.getIn().getBody(FilePersistedNotification.class);

--- a/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
@@ -111,6 +111,7 @@ public class MainRouteBuilder extends RouteBuilder {
                 .setHeader("x-rh-insights-request-id", constant(getRHInsightsRequestId()))
                 .removeHeaders("Camel*")
                 .to("http4://" + uploadHost + "/api/ingress/v1/upload")
+                .to("log:INFO?showBody=true&showHeaders=true")
                 .end();
 
         from("kafka:" + kafkaHost + "?topic={{insights.kafka.upload.topic}}&brokers=" + kafkaHost + "&autoOffsetReset=latest&autoCommitEnable=true")
@@ -131,7 +132,6 @@ public class MainRouteBuilder extends RouteBuilder {
                                 " message :: "+ data + "\n");
                     }
                 })
-                .filter().method(MainRouteBuilder.class, "filterMessages")
                 .unmarshal().json(JsonLibrary.Jackson, FilePersistedNotification.class)
                 .to("direct:download-from-S3");
 
@@ -149,6 +149,7 @@ public class MainRouteBuilder extends RouteBuilder {
                     exchange.getIn().setHeader("filename", rhIdentity.getInternal().get("filename"));
                     exchange.getIn().setHeader("origin", rhIdentity.getInternal().get("origin"));
                 })
+                .filter().method(MainRouteBuilder.class, "filterMessages")
                 .setBody(constant(""))
                 .to("http4://oldhost")
                 .removeHeader("Exchange.HTTP_URI")

--- a/src/main/java/org/jboss/xavier/integrations/route/model/RHIdentity.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/model/RHIdentity.java
@@ -1,5 +1,6 @@
 package org.jboss.xavier.integrations.route.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,6 +12,7 @@ import java.util.Map;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RHIdentity {
     String account_number;
     Map<String,String> internal;

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -17,4 +17,4 @@ amp.port=61616
 sig.autoStartup=true
 
 #Insights kafka
-insights.kafka.topic=platform.upload.testareno
+insights.kafka.upload.topic=platform.upload.testareno

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -47,7 +47,8 @@ sig.autoStartup=false
 
 #Insights kafka
 insights.kafka.host=192.168.1.44:29092
-insights.kafka.topic=platform.upload.available
+insights.kafka.upload.topic=platform.upload.available
+insights.kafka.validation.topic=platform.upload.available
 
 #Insights upload
 insights.upload.host=192.168.1.44:8080

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,7 +48,7 @@ sig.autoStartup=false
 #Insights kafka
 insights.kafka.host=192.168.1.44:29092
 insights.kafka.upload.topic=platform.upload.available
-insights.kafka.validation.topic=platform.upload.available
+insights.kafka.validation.topic=platform.upload.validation
 
 #Insights upload
 insights.upload.host=192.168.1.44:8080

--- a/src/main/resources/okd/analytics_template.json
+++ b/src/main/resources/okd/analytics_template.json
@@ -33,6 +33,9 @@
                     "template.openshift.io/expose-username": "{.data['database-user']}",
                     "template.openshift.io/expose-password": "{.data['database-password']}",
                     "template.openshift.io/expose-database_name": "{.data['database-name']}"
+                },
+                "labels": {
+                    "application": "migration-analytics"
                 }
             },
             "stringData" : {

--- a/src/main/resources/okd/analytics_template_insights_ci.json
+++ b/src/main/resources/okd/analytics_template_insights_ci.json
@@ -1224,6 +1224,22 @@
                                     {
                                         "name": "AMQ_SERVER",
                                         "value": "broker-amq-tcp"
+                                    },
+                                    {
+                                        "name": "INSIGHTS_KAFKA_HOST",
+                                        "value": "${INSIGHTS_KAFKA_HOST}"
+                                    },
+                                    {
+                                        "name": "INSIGHTS_UPLOAD_HOST",
+                                        "value": "${INSIGHTS_UPLOAD_HOST}"
+                                    },
+                                    {
+                                        "name": "INSIGHTS_KAFKA_VALIDATION_TOPIC",
+                                        "value": "${INSIGHTS_KAFKA_VALIDATION_TOPIC}"
+                                    },
+                                    {
+                                        "name": "INSIGHTS_KAFKA_UPLOAD_TOPIC",
+                                        "value": "${INSIGHTS_KAFKA_UPLOAD_TOPIC}"
                                     }
                                 ],
                                 "resources": {

--- a/src/main/resources/okd/analytics_template_insights_ci.json
+++ b/src/main/resources/okd/analytics_template_insights_ci.json
@@ -33,6 +33,9 @@
                     "template.openshift.io/expose-username": "{.data['database-user']}",
                     "template.openshift.io/expose-password": "{.data['database-password']}",
                     "template.openshift.io/expose-database_name": "{.data['database-name']}"
+                },
+                "labels": {
+                    "application": "migration-analytics"
                 }
             },
             "stringData" : {
@@ -1732,6 +1735,10 @@
                 "name": "${DATABASE_SERVICE_NAME}",
                 "annotations": {
                     "template.openshift.io/expose-uri": "postgres://{.spec.clusterIP}:{.spec.ports[?(.name==\"postgresql\")].port}"
+                },
+                "labels": {
+                    "app": "${DATABASE_SERVICE_NAME}-persistent",
+                    "application": "migration-analytics"
                 }
             },
             "spec": {
@@ -1759,7 +1766,6 @@
             "apiVersion": "v1",
             "metadata": {
                 "name": "xavier",
-                "creationTimestamp": null,
                 "labels": {
                     "app": "xavier-http",
                     "application": "migration-analytics",

--- a/src/main/resources/okd/analytics_template_insights_ci.json
+++ b/src/main/resources/okd/analytics_template_insights_ci.json
@@ -1828,7 +1828,7 @@
             },
             "spec": {
                 "accessModes": [
-                    "ReadWriteMany"
+                    "ReadWriteOnce"
                 ],
                 "resources": {
                     "requests": {
@@ -1863,7 +1863,6 @@
             "apiVersion": "v1",
             "metadata": {
                 "name": "myapp-rhdmsvc",
-                "creationTimestamp": null,
                 "labels": {
                     "app": "analytics",
                     "application": "migration-analytics",

--- a/src/main/resources/okd/analytics_template_insights_ci.json
+++ b/src/main/resources/okd/analytics_template_insights_ci.json
@@ -1098,13 +1098,9 @@
             },
             "spec": {
                 "strategy": {
-                    "type": "Rolling",
-                    "rollingParams": {
-                        "updatePeriodSeconds": 1,
-                        "intervalSeconds": 1,
-                        "timeoutSeconds": 600,
-                        "maxUnavailable": "25%",
-                        "maxSurge": "25%"
+                    "type": "Recreate",
+                    "recreateParams": {
+                        "timeoutSeconds": 600
                     },
                     "resources": {},
                     "activeDeadlineSeconds": 21600
@@ -2029,7 +2025,28 @@
             "displayName": "AMQ Streams (Kafka) host",
             "description": "AMQ Streams (Kafka) host",
             "value": "platform-mq-ci-kafka-bootstrap.platform-mq-ci.svc:9092",
-            "required": true
+            "required": false
+        },
+        {
+            "name": "INSIGHTS_UPLOAD_HOST",
+            "displayName": "Insights Upload Service Endpoint",
+            "description": "Insights Upload Service Endpoint",
+            "value": "upload-service.platform-ci:8080",
+            "required": false
+        },
+        {
+            "name": "INSIGHTS_KAFKA_VALIDATION_TOPIC",
+            "displayName": "Kafka topic for upload payload validation",
+            "description": "Kafka topic for upload payload validation",
+            "value": "platform.upload.validation",
+            "required": false
+        },
+        {
+            "name": "INSIGHTS_KAFKA_UPLOAD_TOPIC",
+            "displayName": "Kafka topic for upload payload available",
+            "description": "Kafka topic for upload payload available",
+            "value": "platform.upload.testareno",
+            "required": false
         }
     ]
 }

--- a/src/main/resources/okd/analytics_template_insights_ci.json
+++ b/src/main/resources/okd/analytics_template_insights_ci.json
@@ -1,0 +1,2035 @@
+{
+    "kind": "Template",
+    "apiVersion": "template.openshift.io/v1",
+    "metadata": {
+        "name": "migration-analytics",
+        "creationTimestamp": null
+    },
+    "objects": [
+        {
+            "kind": "Secret",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "eap7-app-secret",
+                "annotations": {
+                    "description": "Default HTTPS keystore (keystore.jks) with name 'jboss' and password 'mykeystorepass' and JGoups keystore (jgroups.jceks) with name 'secret-key' and password 'password'"
+                },
+                "labels": {
+                    "application": "migration-analytics"
+                }
+            },
+            "data": {
+                "jgroups.jceks": "zs7OzgAAAAIAAAABAAAAAwAKc2VjcmV0LWtleQAAAVDQhuHmrO0ABXNyADNjb20uc3VuLmNyeXB0by5wcm92aWRlci5TZWFsZWRPYmplY3RGb3JLZXlQcm90ZWN0b3LNV8pZ5zC7UwIAAHhyABlqYXZheC5jcnlwdG8uU2VhbGVkT2JqZWN0PjY9psO3VHACAARbAA1lbmNvZGVkUGFyYW1zdAACW0JbABBlbmNyeXB0ZWRDb250ZW50cQB+AAJMAAlwYXJhbXNBbGd0ABJMamF2YS9sYW5nL1N0cmluZztMAAdzZWFsQWxncQB+AAN4cHVyAAJbQqzzF/gGCFTgAgAAeHAAAAAPMA0ECHcwLGK6EDyLAgEUdXEAfgAFAAAAmCu9wRKf1aYYUOEWe406ncPtIdm3147G7MJyWUu2kJVY15a2QxeZi9w5J3AF6T64CvylUuQjpcC4DWXwVn9BefntkBR8CzTiH7VxEqVOQ/OkFS29Inoq8t7/NBaTgTdmMkb4ETV1gIsy/+W6kk7QTqxItCkdKKGFE90Be/7yL3tG16TCy/ABKl7CO6PHa44CqK2PUE1oaJ+WdAAWUEJFV2l0aE1ENUFuZFRyaXBsZURFU3QAFlBCRVdpdGhNRDVBbmRUcmlwbGVERVMN658veJP01V2j9y8bQCYIzViutw==",
+                "keystore.jks": "/u3+7QAAAAIAAAABAAAAAQAFamJvc3MAAAFVFbYp5AAABQIwggT+MA4GCisGAQQBKgIRAQEFAASCBOqe/lTeehnds9ffJp/EYKY2K7o9CvvyvgiqvdaGqiZxwWjmoYBEuBxJBUkr7uyYr2g3Viui18djJh9paWdBfPRCEWsLxbMBmig+5OXe1U536PTNZlzkdrwSJpusiwwWLiog/kQ+Gp82VzHxsueNVkewKZ6LvdAq+5Pw7148cxgfnm+2j0La1YnX4/TAtY6A33HjU3HxPxpkLCBP66THxjJvm+n5xg+6eAPu6n/c3mWShhudf0k7FAHLgqMqZt22GMlIv73azdz5kf+opcF8nHN/SDnrgmBbX+GBFvMQ64a3zfLGMnCH8R7L2v5K0uH4AvOHHU9+g7KGk/obPOFyqjloPGIGwzyX4UhxsxP9+wU45RVg02SdoOsqsKYeF7JV1t+uj1+WXDkEaxGYx9u5bFIpkQOuuh6kyf6P6MK8gP6u8cRJeLU/LZCkNMSHq6afbgu/Uu0ZlPFKMLBiX6aKYO0nhp/h3QBzLOVCrWB5nnj90WnZ6Ug8bUjozTTKcdOu8oU47cOesSxPsZzs/KXEuqNP+T34fb4iOKjDXpTZDhIDYanfXb+GMHi/XdY5Q5Xu5w+6ES4ue9grlqfXtMa3G/FgUuJ6dLIXCDAHtS6nxvN3VBd3+pkQKG3iiBMbmBSg03bau5stsD8ol6NGQkoqIhvr1cxFHz+wVzh3UE6FOF+T96rqSuK17UNWnNTSFntHpMYUq+CbD1sTsAmaZ1tIbWBVYEw9G0hpzfFgIqndnEOJ2hD1Z30cStVvSamTlY1hYwxw9/qVUGxzRyQF1a4U8wuYyJNSLZmLwF4jmtkP/kvzhOJ9nr9ZHpuZcW8v5OuHpeTGb+bq+23T+1w0uK3x+O0TnZAFKN4UyZN6JWH2LI+jS+95sTt1fgV1gpY7/qtgX26BWPGQw6+ynRT68EREneUH7c8z3W8mkyfeOl+ffi3n4BYmkki6feSJNbkNdRncpFO83qIk3EtE9RNOMjU1ih8w+KrzZXm2LIINYqc6FkR+tACeGcJwPRkv7paGE3fI7JacYPrJsIf8C055NqbW1HFhplhY/zTbSuGH0SaseZ2lzkGVaVG8pzsNBlBX8eR4oL7LWAXhos1uJdg9cVIC2UZ+bBkBlUpEeWi7LryLL+Glg//iMp3W93nm+S6UJVUipVMgCMgHrXZjWQN0tGvPOxBUIM5IrxcrWsjEA0OJDsa0KCbI8R397FP3QZqB9hJPDs6Lb+64XGmkmAixLYLP2LczlmmoJ6pnGTdzqGjf/au1FzTq/Pikundn47Lt0ZsA9D5Wq958zr0U8Zc3X2OewAd/MKh7u5TOAJs870wHZPIjZss9lTwYJ1VfCP9/x4c8wfoas1mLrxoaTx4axIiTn8bMK60fq5s2DLpnDNgGS0g2tsyqw6+BPCKuwNj1dc5dl0fupIZxLB4+FeTcr7WaDslBl5QIyrM6ljknzd+r3U5ndtBiTBnFutD4+YFOcGPXm1qE7R/1Olmt+ZwnB8O7CtOGldTv/Imoa+en8YFT0TH9gPstso6ERJIP4UbIxxxJF+soqNVkK5fY0qRSksosJJJTKdD8BNl9skcPo8S9J7TRtcBsbPytU/1DhnL19D+bp0o5NRLAWse2sTOv3dSZiBPIAeL5oSaSBkJ9GbZcVc95d7ga3cNgbZuvcNPLov+F1WsEYYZcM/zjhvevAAAAAQAFWC41MDkAAAOBMIIDfTCCAmWgAwIBAgIEHPuEUDANBgkqhkiG9w0BAQsFADBvMQswCQYDVQQGEwJVUzEQMA4GA1UECBMHTXlTdGF0ZTEPMA0GA1UEBxMGTXlDaXR5MRcwFQYDVQQKEw5NeU9yZ2FuaXphdGlvbjESMBAGA1UECxMJTXlPcmdVbml0MRAwDgYDVQQDEwdFeGFtcGxlMB4XDTE2MDYwMzEwMDE0NVoXDTI2MDYwMTEwMDE0NVowbzELMAkGA1UEBhMCVVMxEDAOBgNVBAgTB015U3RhdGUxDzANBgNVBAcTBk15Q2l0eTEXMBUGA1UEChMOTXlPcmdhbml6YXRpb24xEjAQBgNVBAsTCU15T3JnVW5pdDEQMA4GA1UEAxMHRXhhbXBsZTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL12YRIsnxFfnXSOLn8GtCWf0pJr/NzSFDV7M1I0nLlytu7dD/XAwvRTV6CFEvZJ8a4Q5NmKDkB1XofN7uebEhIANcizwtu61JXyic26kQB3IhK4nb5BChIgJbvfXg4IiazbWIHR6cAyRWT/M6rXVVUNDIPRZ84O7rng2vKvZezGHS9BbsoewyhF71fWTmvu2s7Dcm1sI6bRxJnF4BCQdMEc8dfPqjWCQUqkvkPN4wyHUzVlQE0/pbOW4YN668dBSmTGHTWaUvEXgX333gAlG07YcbJtjqJznurkCKLrGssX2ozGQg84GKg9+Sq+nwN5a09Rfhn4UBRGrJ4MpZDpKAkCAwEAAaMhMB8wHQYDVR0OBBYEFJMKA17Zl2R5M8pqpmdUWFEERulHMA0GCSqGSIb3DQEBCwUAA4IBAQCFJQeVl+7XD9Is6lGHPgOr8Ep8pSHwCBY+95C4I7KPYapXB+U9gi9bKvVElfDD+IMPfqg2hRuFCnW3MQId/6QU+/c7+fwOnqE0oi6xo8nl7qx48Y/Ih3jXo3q7JON6CfrJHMSw47+gYi8c66S6EOePi2aGySQNBwqop85kEUhDEl6eGAAEo66+BrCUjwPNK3R5mGtx38FM54OibLkmDMS8pFfBN7qQ1C35JUdFDDJcNEBZ1WGIbkLxyIFsogJa1x6j235Fst9MASxeu5+xO3/WVHcLHQAZqJ/xZadEJAg2+YkPEhsrIEoFhRr3Hg13ECqD1W6aSW5kE5wPoWjru1gNUXYHaE8+iikx9yyc8V8V4CG63qk="
+            },
+            "type": "Opaque"
+        },
+        {
+            "kind": "Secret",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${DATABASE_SERVICE_NAME}",
+                "annotations": {
+                    "template.openshift.io/expose-username": "{.data['database-user']}",
+                    "template.openshift.io/expose-password": "{.data['database-password']}",
+                    "template.openshift.io/expose-database_name": "{.data['database-name']}"
+                }
+            },
+            "stringData" : {
+                "database-user" : "${POSTGRESQL_USER}",
+                "database-password" : "${POSTGRESQL_PASSWORD}",
+                "database-name" : "${POSTGRESQL_DATABASE}"
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "apps.openshift.io/v1",
+            "metadata": {
+                "name": "broker-amq",
+                "generation": 2,
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "amq-broker",
+                    "application": "migration-analytics",
+                    "template": "amq-broker-73-basic",
+                    "xpaas": "1.4.16"
+                }
+            },
+            "spec": {
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "deploymentConfig": "broker-amq"
+                },
+                "strategy": {
+                    "type": "Rolling",
+                    "rollingParams": {
+                        "updatePeriodSeconds": 1,
+                        "intervalSeconds": 1,
+                        "timeoutSeconds": 600,
+                        "maxUnavailable": "25%",
+                        "maxSurge": 0
+                    },
+                    "resources": {},
+                    "activeDeadlineSeconds": 21600
+                },
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "test": false,
+                "template": {
+                    "metadata": {
+                        "name": "broker-amq",
+                        "labels": {
+                            "application": "migration-analytics",
+                            "deploymentConfig": "broker-amq"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "broker-amq",
+                                "image": "registry.redhat.io/amq-broker-7/amq-broker-73-openshift:7.3",
+                                "ports": [
+                                    {
+                                        "name": "console-jolokia",
+                                        "containerPort": 8161,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "amqp",
+                                        "containerPort": 5672,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "mqtt",
+                                        "containerPort": 1883,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "stomp",
+                                        "containerPort": 61613,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "artemis",
+                                        "containerPort": 61616,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "AMQ_USER",
+                                        "value": "userk0N"
+                                    },
+                                    {
+                                        "name": "AMQ_PASSWORD",
+                                        "value": "i7MN2pkw"
+                                    },
+                                    {
+                                        "name": "AMQ_ROLE",
+                                        "value": "admin"
+                                    },
+                                    {
+                                        "name": "AMQ_NAME",
+                                        "value": "broker"
+                                    },
+                                    {
+                                        "name": "AMQ_TRANSPORTS",
+                                        "value": "openwire,amqp,stomp,mqtt,hornetq"
+                                    },
+                                    {
+                                        "name": "AMQ_QUEUES"
+                                    },
+                                    {
+                                        "name": "AMQ_ADDRESSES"
+                                    },
+                                    {
+                                        "name": "AMQ_GLOBAL_MAX_SIZE",
+                                        "value": "100 gb"
+                                    },
+                                    {
+                                        "name": "AMQ_REQUIRE_LOGIN"
+                                    },
+                                    {
+                                        "name": "AMQ_EXTRA_ARGS"
+                                    },
+                                    {
+                                        "name": "AMQ_ANYCAST_PREFIX"
+                                    },
+                                    {
+                                        "name": "AMQ_MULTICAST_PREFIX"
+                                    }
+                                ],
+                                "resources": {},
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "/opt/amq/bin/readinessProbe.sh"
+                                        ]
+                                    },
+                                    "timeoutSeconds": 1,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "failureThreshold": 3
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "imagePullPolicy": "Always"
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "terminationGracePeriodSeconds": 60,
+                        "dnsPolicy": "ClusterFirst",
+                        "securityContext": {},
+                        "schedulerName": "default-scheduler"
+                    }
+                }
+            },
+            "status": {
+                "latestVersion": 0,
+                "observedGeneration": 0,
+                "replicas": 0,
+                "updatedReplicas": 0,
+                "availableReplicas": 0,
+                "unavailableReplicas": 0
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "apps.openshift.io/v1",
+            "metadata": {
+                "name": "analytics-kieserver",
+                "generation": 2,
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "analytics",
+                    "application": "migration-analytics",
+                    "rhdm": "1.0",
+                    "service": "analytics-kieserver",
+                    "template": "rhdm73-authoring"
+                },
+                "annotations": {
+                    "template.alpha.openshift.io/wait-for-ready": "true"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate",
+                    "recreateParams": {
+                        "timeoutSeconds": 600
+                    },
+                    "resources": {},
+                    "activeDeadlineSeconds": 21600
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "analytics-kieserver"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${NAMESPACE}",
+                                "name": "rhdm73-kieserver-openshift:1.0"
+                            }
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "test": false,
+                "selector": {
+                    "deploymentConfig": "analytics-kieserver"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "analytics-kieserver",
+                        "creationTimestamp": null,
+                        "labels": {
+                            "application": "migration-analytics",
+                            "deploymentConfig": "analytics-kieserver",
+                            "service": "analytics-kieserver"
+                        }
+                    },
+                    "spec": {
+                        "volumes": [
+                            {
+                                "name": "kieserver-keystore-volume",
+                                "secret": {
+                                    "secretName": "eap7-app-secret",
+                                    "defaultMode": 420
+                                }
+                            }
+                        ],
+                        "containers": [
+                            {
+                                "name": "analytics-kieserver",
+                                "image": "172.30.1.1:5000/openshift/rhdm73-kieserver-openshift@sha256:0db3dd7fad9bdd144c758482d59c55a19867bbb9429fee58ed8bdf11f3f2f0b0",
+                                "ports": [
+                                    {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "http",
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "https",
+                                        "containerPort": 8443,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KIE_ADMIN_USER",
+                                        "value": "adminUser"
+                                    },
+                                    {
+                                        "name": "KIE_ADMIN_PWD",
+                                        "value": "SxNhwF2!"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_MODE",
+                                        "value": "DEVELOPMENT"
+                                    },
+                                    {
+                                        "name": "KIE_MBEANS",
+                                        "value": "enabled"
+                                    },
+                                    {
+                                        "name": "DROOLS_SERVER_FILTER_CLASSES",
+                                        "value": "true"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_BYPASS_AUTH_USER",
+                                        "value": "false"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_USER",
+                                        "value": "controllerUser"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_PWD",
+                                        "value": "AYdlha0!"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_TOKEN"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_SERVICE",
+                                        "value": "analytics-rhdmcentr"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_PROTOCOL",
+                                        "value": "ws"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_ID",
+                                        "value": "analytics-kieserver"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_ROUTE_NAME",
+                                        "value": "analytics-kieserver"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_USE_SECURE_ROUTE_NAME",
+                                        "value": "false"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_USER",
+                                        "value": "executionUser"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_PWD",
+                                        "value": "rksxsp2!"
+                                    },
+                                    {
+                                        "name": "MAVEN_MIRROR_URL"
+                                    },
+                                    {
+                                        "name": "MAVEN_REPOS",
+                                        "value": "RHDMCENTR,EXTERNAL"
+                                    },
+                                    {
+                                        "name": "RHDMCENTR_MAVEN_REPO_SERVICE",
+                                        "value": "analytics-rhdmcentr"
+                                    },
+                                    {
+                                        "name": "RHDMCENTR_MAVEN_REPO_PATH",
+                                        "value": "/maven2/"
+                                    },
+                                    {
+                                        "name": "RHDMCENTR_MAVEN_REPO_USERNAME",
+                                        "value": "mavenUser"
+                                    },
+                                    {
+                                        "name": "RHDMCENTR_MAVEN_REPO_PASSWORD",
+                                        "value": "HipiAC1!"
+                                    },
+                                    {
+                                        "name": "EXTERNAL_MAVEN_REPO_ID"
+                                    },
+                                    {
+                                        "name": "EXTERNAL_MAVEN_REPO_URL"
+                                    },
+                                    {
+                                        "name": "EXTERNAL_MAVEN_REPO_USERNAME"
+                                    },
+                                    {
+                                        "name": "EXTERNAL_MAVEN_REPO_PASSWORD"
+                                    },
+                                    {
+                                        "name": "HTTPS_KEYSTORE_DIR",
+                                        "value": "/etc/kieserver-secret-volume"
+                                    },
+                                    {
+                                        "name": "HTTPS_KEYSTORE",
+                                        "value": "keystore.jks"
+                                    },
+                                    {
+                                        "name": "HTTPS_NAME",
+                                        "value": "jboss"
+                                    },
+                                    {
+                                        "name": "HTTPS_PASSWORD",
+                                        "value": "mykeystorepass"
+                                    },
+                                    {
+                                        "name": "SSO_URL"
+                                    },
+                                    {
+                                        "name": "SSO_OPENIDCONNECT_DEPLOYMENTS",
+                                        "value": "ROOT.war"
+                                    },
+                                    {
+                                        "name": "SSO_REALM"
+                                    },
+                                    {
+                                        "name": "SSO_SECRET"
+                                    },
+                                    {
+                                        "name": "SSO_CLIENT"
+                                    },
+                                    {
+                                        "name": "SSO_USERNAME"
+                                    },
+                                    {
+                                        "name": "SSO_PASSWORD"
+                                    },
+                                    {
+                                        "name": "SSO_DISABLE_SSL_CERTIFICATE_VALIDATION",
+                                        "value": "false"
+                                    },
+                                    {
+                                        "name": "SSO_PRINCIPAL_ATTRIBUTE",
+                                        "value": "preferred_username"
+                                    },
+                                    {
+                                        "name": "HOSTNAME_HTTP"
+                                    },
+                                    {
+                                        "name": "HOSTNAME_HTTPS"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_URL"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_BIND_DN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_BIND_CREDENTIAL"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_JAAS_SECURITY_DOMAIN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_BASE_CTX_DN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_BASE_FILTER"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_SEARCH_SCOPE"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_SEARCH_TIME_LIMIT"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_PARSE_USERNAME"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_USERNAME_BEGIN_STRING"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_USERNAME_END_STRING"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLE_ATTRIBUTE_ID"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLES_CTX_DN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLE_FILTER"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLE_RECURSION"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_DEFAULT_ROLE"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLE_NAME_ATTRIBUTE_ID"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_PARSE_ROLE_NAME_FROM_DN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLE_ATTRIBUTE_IS_DN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_REFERRAL_USER_ATTRIBUTE_ID_TO_CHECK"
+                                    },
+                                    {
+                                        "name": "AUTH_ROLE_MAPPER_ROLES_PROPERTIES"
+                                    },
+                                    {
+                                        "name": "AUTH_ROLE_MAPPER_REPLACE_ROLE"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "1",
+                                        "memory": "2Gi"
+                                    },
+                                    "requests": {
+                                        "cpu": "600m",
+                                        "memory": "2Gi"
+                                    }
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "name": "kieserver-keystore-volume",
+                                        "readOnly": true,
+                                        "mountPath": "/etc/kieserver-secret-volume"
+                                    }
+                                ],
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "curl --fail --silent -u 'adminUser:SxNhwF2!' http://localhost:8080/services/rest/server/healthcheck"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "timeoutSeconds": 2,
+                                    "periodSeconds": 15,
+                                    "successThreshold": 1,
+                                    "failureThreshold": 3
+                                },
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "curl --fail --silent -u 'adminUser:SxNhwF2!' http://localhost:8080/services/rest/server/readycheck"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 60,
+                                    "timeoutSeconds": 2,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "failureThreshold": 6
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "imagePullPolicy": "Always"
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "terminationGracePeriodSeconds": 60,
+                        "dnsPolicy": "ClusterFirst",
+                        "serviceAccountName": "myapp-rhdmsvc",
+                        "serviceAccount": "myapp-rhdmsvc",
+                        "securityContext": {},
+                        "schedulerName": "default-scheduler"
+                    }
+                }
+            },
+            "status": {
+                "latestVersion": 0,
+                "observedGeneration": 0,
+                "replicas": 0,
+                "updatedReplicas": 0,
+                "availableReplicas": 0,
+                "unavailableReplicas": 0
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "apps.openshift.io/v1",
+            "metadata": {
+                "name": "analytics-rhdmcentr",
+                "generation": 2,
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "analytics",
+                    "application": "migration-analytics",
+                    "rhdm": "1.0",
+                    "service": "analytics-rhdmcentr",
+                    "template": "rhdm73-authoring"
+                },
+                "annotations": {
+                    "template.alpha.openshift.io/wait-for-ready": "true"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate",
+                    "recreateParams": {
+                        "timeoutSeconds": 600
+                    },
+                    "resources": {},
+                    "activeDeadlineSeconds": 21600
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "analytics-rhdmcentr"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${NAMESPACE}",
+                                "name": "rhdm73-decisioncentral-openshift:1.0"
+                            }
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "test": false,
+                "selector": {
+                    "deploymentConfig": "analytics-rhdmcentr"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "analytics-rhdmcentr",
+                        "creationTimestamp": null,
+                        "labels": {
+                            "application": "migration-analytics",
+                            "deploymentConfig": "analytics-rhdmcentr",
+                            "service": "analytics-rhdmcentr"
+                        }
+                    },
+                    "spec": {
+                        "volumes": [
+                            {
+                                "name": "decisioncentral-keystore-volume",
+                                "secret": {
+                                    "secretName": "eap7-app-secret",
+                                    "defaultMode": 420
+                                }
+                            },
+                            {
+                                "name": "analytics-rhdmcentr-pvol",
+                                "persistentVolumeClaim": {
+                                    "claimName": "analytics-rhdmcentr-claim"
+                                }
+                            }
+                        ],
+                        "containers": [
+                            {
+                                "name": "analytics-rhdmcentr",
+                                "image": "172.30.1.1:5000/openshift/rhdm73-decisioncentral-openshift@sha256:f7b7bf8cb010e8d5e2222c8c099124b5fa08955985722c5dd89d806933c08b5c",
+                                "ports": [
+                                    {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "http",
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "https",
+                                        "containerPort": 8443,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "git-ssh",
+                                        "containerPort": 8001,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KIE_ADMIN_USER",
+                                        "value": "adminUser"
+                                    },
+                                    {
+                                        "name": "KIE_ADMIN_PWD",
+                                        "value": "SxNhwF2!"
+                                    },
+                                    {
+                                        "name": "KIE_MBEANS",
+                                        "value": "enabled"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_USER",
+                                        "value": "controllerUser"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_PWD",
+                                        "value": "AYdlha0!"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_CONTROLLER_TOKEN"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_USER",
+                                        "value": "executionUser"
+                                    },
+                                    {
+                                        "name": "KIE_SERVER_PWD",
+                                        "value": "rksxsp2!"
+                                    },
+                                    {
+                                        "name": "WORKBENCH_ROUTE_NAME",
+                                        "value": "analytics-rhdmcentr"
+                                    },
+                                    {
+                                        "name": "MAVEN_MIRROR_URL"
+                                    },
+                                    {
+                                        "name": "MAVEN_REPO_ID"
+                                    },
+                                    {
+                                        "name": "MAVEN_REPO_URL"
+                                    },
+                                    {
+                                        "name": "MAVEN_REPO_USERNAME"
+                                    },
+                                    {
+                                        "name": "MAVEN_REPO_PASSWORD"
+                                    },
+                                    {
+                                        "name": "KIE_MAVEN_USER",
+                                        "value": "mavenUser"
+                                    },
+                                    {
+                                        "name": "KIE_MAVEN_PWD",
+                                        "value": "HipiAC1!"
+                                    },
+                                    {
+                                        "name": "GIT_HOOKS_DIR"
+                                    },
+                                    {
+                                        "name": "HTTPS_KEYSTORE_DIR",
+                                        "value": "/etc/decisioncentral-secret-volume"
+                                    },
+                                    {
+                                        "name": "HTTPS_KEYSTORE",
+                                        "value": "keystore.jks"
+                                    },
+                                    {
+                                        "name": "HTTPS_NAME",
+                                        "value": "jboss"
+                                    },
+                                    {
+                                        "name": "HTTPS_PASSWORD",
+                                        "value": "mykeystorepass"
+                                    },
+                                    {
+                                        "name": "SSO_URL"
+                                    },
+                                    {
+                                        "name": "SSO_OPENIDCONNECT_DEPLOYMENTS",
+                                        "value": "ROOT.war"
+                                    },
+                                    {
+                                        "name": "SSO_REALM"
+                                    },
+                                    {
+                                        "name": "SSO_SECRET"
+                                    },
+                                    {
+                                        "name": "SSO_CLIENT"
+                                    },
+                                    {
+                                        "name": "SSO_USERNAME"
+                                    },
+                                    {
+                                        "name": "SSO_PASSWORD"
+                                    },
+                                    {
+                                        "name": "SSO_DISABLE_SSL_CERTIFICATE_VALIDATION",
+                                        "value": "false"
+                                    },
+                                    {
+                                        "name": "SSO_PRINCIPAL_ATTRIBUTE",
+                                        "value": "preferred_username"
+                                    },
+                                    {
+                                        "name": "HOSTNAME_HTTP"
+                                    },
+                                    {
+                                        "name": "HOSTNAME_HTTPS"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_URL"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_BIND_DN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_BIND_CREDENTIAL"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_JAAS_SECURITY_DOMAIN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_BASE_CTX_DN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_BASE_FILTER"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_SEARCH_SCOPE"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_SEARCH_TIME_LIMIT"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_PARSE_USERNAME"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_USERNAME_BEGIN_STRING"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_USERNAME_END_STRING"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLE_ATTRIBUTE_ID"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLES_CTX_DN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLE_FILTER"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLE_RECURSION"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_DEFAULT_ROLE"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLE_NAME_ATTRIBUTE_ID"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_PARSE_ROLE_NAME_FROM_DN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_ROLE_ATTRIBUTE_IS_DN"
+                                    },
+                                    {
+                                        "name": "AUTH_LDAP_REFERRAL_USER_ATTRIBUTE_ID_TO_CHECK"
+                                    },
+                                    {
+                                        "name": "AUTH_ROLE_MAPPER_ROLES_PROPERTIES"
+                                    },
+                                    {
+                                        "name": "AUTH_ROLE_MAPPER_REPLACE_ROLE"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "memory": "2Gi",
+                                        "cpu": "1"
+                                    },
+                                    "requests": {
+                                        "cpu": "600m",
+                                        "memory": "2Gi"
+                                    }
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "name": "decisioncentral-keystore-volume",
+                                        "readOnly": true,
+                                        "mountPath": "/etc/decisioncentral-secret-volume"
+                                    },
+                                    {
+                                        "name": "analytics-rhdmcentr-pvol",
+                                        "mountPath": "/opt/eap/standalone/data/kie"
+                                    }
+                                ],
+                                "livenessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "curl --fail --silent -u 'adminUser:SxNhwF2!' http://localhost:8080/kie-wb.jsp"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "timeoutSeconds": 2,
+                                    "periodSeconds": 15,
+                                    "successThreshold": 1,
+                                    "failureThreshold": 3
+                                },
+                                "readinessProbe": {
+                                    "exec": {
+                                        "command": [
+                                            "/bin/bash",
+                                            "-c",
+                                            "curl --fail --silent -u 'adminUser:SxNhwF2!' http://localhost:8080/kie-wb.jsp"
+                                        ]
+                                    },
+                                    "initialDelaySeconds": 60,
+                                    "timeoutSeconds": 2,
+                                    "periodSeconds": 30,
+                                    "successThreshold": 1,
+                                    "failureThreshold": 6
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "imagePullPolicy": "Always"
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "terminationGracePeriodSeconds": 60,
+                        "dnsPolicy": "ClusterFirst",
+                        "serviceAccountName": "myapp-rhdmsvc",
+                        "serviceAccount": "myapp-rhdmsvc",
+                        "securityContext": {},
+                        "schedulerName": "default-scheduler"
+                    }
+                }
+            },
+            "status": {
+                "latestVersion": 0,
+                "observedGeneration": 0,
+                "replicas": 0,
+                "updatedReplicas": 0,
+                "availableReplicas": 0,
+                "unavailableReplicas": 0
+            }
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${DATABASE_SERVICE_NAME}",
+                "labels": {
+                    "app": "${DATABASE_SERVICE_NAME}-persistent",
+                    "application": "migration-analytics"
+                },
+                "annotations": {
+                    "template.alpha.openshift.io/wait-for-ready": "true"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "postgresql"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "namespace": "${NAMESPACE}",
+                                "name": "postgresql:${POSTGRESQL_VERSION}"
+                            }
+                        }
+                    },
+                    {
+                        "type": "ConfigChange"
+                    }
+                ],
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "test": false,
+                "selector": {
+                    "name": "${DATABASE_SERVICE_NAME}"
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "name": "${DATABASE_SERVICE_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "postgresql",
+                                "image": " ",
+                                "ports": [
+                                    {
+                                        "containerPort": 5432,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "readinessProbe": {
+                                    "timeoutSeconds": 1,
+                                    "initialDelaySeconds": 5,
+                                    "exec": {
+                                        "command": [ "/usr/libexec/check-container" ]
+                                    }
+                                },
+                                "livenessProbe": {
+                                    "timeoutSeconds": 10,
+                                    "initialDelaySeconds": 120,
+                                    "exec": {
+                                        "command": [ "/usr/libexec/check-container", "--live" ]
+                                    }
+                                },
+                                "env": [
+                                    {
+                                        "name": "POSTGRESQL_USER",
+                                        "valueFrom": {
+                                            "secretKeyRef" : {
+                                                "name" : "${DATABASE_SERVICE_NAME}",
+                                                "key" : "database-user"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_PASSWORD",
+                                        "valueFrom": {
+                                            "secretKeyRef" : {
+                                                "name" : "${DATABASE_SERVICE_NAME}",
+                                                "key" : "database-password"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_DATABASE",
+                                        "valueFrom": {
+                                            "secretKeyRef" : {
+                                                "name" : "${DATABASE_SERVICE_NAME}",
+                                                "key" : "database-name"
+                                            }
+                                        }
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "memory": "${POSTGRESQL_MEMORY_LIMIT}"
+                                    }
+                                },
+                                "volumeMounts": [
+                                    {
+                                        "name": "${DATABASE_SERVICE_NAME}-data",
+                                        "mountPath": "/var/lib/pgsql/data"
+                                    }
+                                ],
+                                "terminationMessagePath": "/dev/termination-log",
+                                "imagePullPolicy": "IfNotPresent",
+                                "capabilities": {},
+                                "securityContext": {
+                                    "capabilities": {},
+                                    "privileged": false
+                                }
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "name": "${DATABASE_SERVICE_NAME}-data",
+                                "persistentVolumeClaim": {
+                                    "claimName": "${DATABASE_SERVICE_NAME}"
+                                }
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "dnsPolicy": "ClusterFirst"
+                    }
+                }
+            },
+            "status": {}
+        },
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "apps.openshift.io/v1",
+            "metadata": {
+                "name": "analytics-integration",
+                "generation": 63,
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "analytics-integration",
+                    "application": "migration-analytics",
+                    "component": "analytics-integration",
+                    "provider": "s2i",
+                    "template": "analytics-integration",
+                    "version": "1.0.0.fuse-730046-redhat-00002"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Rolling",
+                    "rollingParams": {
+                        "updatePeriodSeconds": 1,
+                        "intervalSeconds": 1,
+                        "timeoutSeconds": 600,
+                        "maxUnavailable": "25%",
+                        "maxSurge": "25%"
+                    },
+                    "resources": {},
+                    "activeDeadlineSeconds": 21600
+                },
+                "triggers": [
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "type": "ImageChange",
+                        "imageChangeParams": {
+                            "automatic": true,
+                            "containerNames": [
+                                "analytics-integration"
+                            ],
+                            "from": {
+                                "kind": "ImageStreamTag",
+                                "name": "analytics-integration:latest"
+                            }
+                        }
+                    }
+                ],
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "test": false,
+                "selector": {
+                    "app": "analytics-integration",
+                    "component": "analytics-integration",
+                    "deploymentconfig": "analytics-integration",
+                    "provider": "s2i",
+                    "version": "1.0.0.fuse-730046-redhat-00002"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "analytics-integration",
+                            "component": "analytics-integration",
+                            "deploymentconfig": "analytics-integration",
+                            "provider": "s2i",
+                            "version": "1.0.0.fuse-730046-redhat-00002"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "analytics-integration",
+                                "image": "library/analytics-integration:latest",
+                                "ports": [
+                                    {
+                                        "name": "jolokia",
+                                        "containerPort": 8778,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "name": "rest",
+                                        "containerPort": 8080,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "KUBERNETES_NAMESPACE",
+                                        "valueFrom": {
+                                            "fieldRef": {
+                                                "apiVersion": "v1",
+                                                "fieldPath": "metadata.namespace"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "KIESERVER_SERVICE",
+                                        "value": "analytics-kieserver"
+                                    },
+                                    {
+                                        "name": "KIESERVER_USERNAME",
+                                        "value": "executionUser"
+                                    },
+                                    {
+                                        "name": "KIESERVER_PASSWORD",
+                                        "value": "rksxsp2!"
+                                    },
+                                    {
+                                        "name": "KIESERVER_PATH",
+                                        "value": "services/rest/server/containers/instances/${kieserver.container}"
+                                    },
+                                    {
+                                        "name": "KIESERVER_CONTAINER",
+                                        "value": "sample-analytics_1.0.0-SNAPSHOT"
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_USER",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": "${DATABASE_SERVICE_NAME}",
+                                                "key": "database-user"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_PASSWORD",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": "${DATABASE_SERVICE_NAME}",
+                                                "key": "database-password"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "POSTGRESQL_DATABASE",
+                                        "valueFrom": {
+                                            "secretKeyRef": {
+                                                "name": "${DATABASE_SERVICE_NAME}",
+                                                "key": "database-name"
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "name": "AMQ_SERVER",
+                                        "value": "broker-amq-tcp"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "1",
+                                        "memory": "512Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "400m",
+                                        "memory": "512Mi"
+                                    }
+                                },
+                                "livenessProbe": {
+                                    "httpGet": {
+                                        "path": "/health",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 180,
+                                    "timeoutSeconds": 1,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "failureThreshold": 3
+                                },
+                                "readinessProbe": {
+                                    "httpGet": {
+                                        "path": "/health",
+                                        "port": 8081,
+                                        "scheme": "HTTP"
+                                    },
+                                    "initialDelaySeconds": 10,
+                                    "timeoutSeconds": 1,
+                                    "periodSeconds": 10,
+                                    "successThreshold": 1,
+                                    "failureThreshold": 3
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "imagePullPolicy": "Always"
+                            }
+                        ],
+                        "restartPolicy": "Always",
+                        "terminationGracePeriodSeconds": 30,
+                        "dnsPolicy": "ClusterFirst",
+                        "securityContext": {},
+                        "schedulerName": "default-scheduler"
+                    }
+                }
+            },
+            "status": {
+                "latestVersion": 0,
+                "observedGeneration": 0,
+                "replicas": 0,
+                "updatedReplicas": 0,
+                "availableReplicas": 0,
+                "unavailableReplicas": 0
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "route.openshift.io/v1",
+            "metadata": {
+                "name": "amq-console",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "amq-broker",
+                    "application": "migration-analytics",
+                    "template": "amq-broker-73-basic",
+                    "xpaas": "1.4.16"
+                },
+                "annotations": {
+                    "openshift.io/host.generated": "true"
+                }
+            },
+            "spec": {
+                "host": "",
+                "to": {
+                    "kind": "Service",
+                    "name": "broker-amq-jolokia",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "route.openshift.io/v1",
+            "metadata": {
+                "name": "analytics-kieserver",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "analytics",
+                    "application": "migration-analytics",
+                    "rhdm": "1.0",
+                    "service": "analytics-kieserver",
+                    "template": "rhdm73-authoring"
+                },
+                "annotations": {
+                    "description": "Route for KIE server's http service.",
+                    "openshift.io/host.generated": "true"
+                }
+            },
+            "spec": {
+                "host": "",
+                "to": {
+                    "kind": "Service",
+                    "name": "analytics-kieserver",
+                    "weight": 100
+                },
+                "port": {
+                    "targetPort": "http"
+                },
+                "wildcardPolicy": "None"
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "route.openshift.io/v1",
+            "metadata": {
+                "name": "analytics-rhdmcentr",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "analytics",
+                    "application": "migration-analytics",
+                    "rhdm": "1.0",
+                    "service": "analytics-rhdmcentr",
+                    "template": "rhdm73-authoring"
+                },
+                "annotations": {
+                    "description": "Route for Decision Central's http service.",
+                    "haproxy.router.openshift.io/timeout": "60s",
+                    "openshift.io/host.generated": "true"
+                }
+            },
+            "spec": {
+                "host": "",
+                "to": {
+                    "kind": "Service",
+                    "name": "analytics-rhdmcentr",
+                    "weight": 100
+                },
+                "port": {
+                    "targetPort": "http"
+                },
+                "wildcardPolicy": "None"
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "route.openshift.io/v1",
+            "metadata": {
+                "name": "xavier",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "xavier-http",
+                    "application": "migration-analytics"
+                },
+                "annotations": {
+                    "openshift.io/host.generated": "true"
+                }
+            },
+            "spec": {
+                "host": "",
+                "to": {
+                    "kind": "Service",
+                    "name": "xavier",
+                    "weight": 100
+                },
+                "port": {
+                    "targetPort": "http"
+                },
+                "wildcardPolicy": "None"
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "route.openshift.io/v1",
+            "metadata": {
+                "name": "secure-analytics-kieserver",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "analytics",
+                    "application": "migration-analytics",
+                    "rhdm": "1.0",
+                    "service": "analytics-kieserver",
+                    "template": "rhdm73-authoring"
+                },
+                "annotations": {
+                    "description": "Route for KIE server's https service.",
+                    "openshift.io/host.generated": "true"
+                }
+            },
+            "spec": {
+                "host": "",
+                "to": {
+                    "kind": "Service",
+                    "name": "analytics-kieserver",
+                    "weight": 100
+                },
+                "port": {
+                    "targetPort": "https"
+                },
+                "tls": {
+                    "termination": "passthrough"
+                },
+                "wildcardPolicy": "None"
+            }
+        },
+        {
+            "kind": "Route",
+            "apiVersion": "route.openshift.io/v1",
+            "metadata": {
+                "name": "secure-analytics-rhdmcentr",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "analytics",
+                    "application": "migration-analytics",
+                    "rhdm": "1.0",
+                    "service": "analytics-rhdmcentr",
+                    "template": "rhdm73-authoring"
+                },
+                "annotations": {
+                    "description": "Route for Decision Central's https service.",
+                    "haproxy.router.openshift.io/timeout": "60s",
+                    "openshift.io/host.generated": "true"
+                }
+            },
+            "spec": {
+                "host": "",
+                "to": {
+                    "kind": "Service",
+                    "name": "analytics-rhdmcentr",
+                    "weight": 100
+                },
+                "port": {
+                    "targetPort": "https"
+                },
+                "tls": {
+                    "termination": "passthrough"
+                },
+                "wildcardPolicy": "None"
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "broker-amq-amqp",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "amq-broker",
+                    "application": "migration-analytics",
+                    "template": "amq-broker-73-basic",
+                    "xpaas": "1.4.16"
+                },
+                "annotations": {
+                    "description": "The broker's AMQP port."
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "protocol": "TCP",
+                        "port": 5672,
+                        "targetPort": 5672
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "broker-amq"
+                },
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "broker-amq-jolokia",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "amq-broker",
+                    "application": "migration-analytics",
+                    "template": "amq-broker-73-basic",
+                    "xpaas": "1.4.16"
+                },
+                "annotations": {
+                    "description": "The broker's console and Jolokia port."
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "protocol": "TCP",
+                        "port": 8161,
+                        "targetPort": 8161
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "broker-amq"
+                },
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "broker-amq-mqtt",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "amq-broker",
+                    "application": "migration-analytics",
+                    "template": "amq-broker-73-basic",
+                    "xpaas": "1.4.16"
+                },
+                "annotations": {
+                    "description": "The broker's MQTT port."
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "protocol": "TCP",
+                        "port": 1883,
+                        "targetPort": 1883
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "broker-amq"
+                },
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "broker-amq-stomp",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "amq-broker",
+                    "application": "migration-analytics",
+                    "template": "amq-broker-73-basic",
+                    "xpaas": "1.4.16"
+                },
+                "annotations": {
+                    "description": "The broker's STOMP port."
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "protocol": "TCP",
+                        "port": 61613,
+                        "targetPort": 61613
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "broker-amq"
+                },
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "broker-amq-tcp",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "amq-broker",
+                    "application": "migration-analytics",
+                    "template": "amq-broker-73-basic",
+                    "xpaas": "1.4.16"
+                },
+                "annotations": {
+                    "description": "The broker's OpenWire port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"broker-amq-amqp\", \"kind\": \"Service\"},{\"name\": \"broker-amq-mqtt\", \"kind\": \"Service\"},{\"name\": \"broker-amq-stomp\", \"kind\": \"Service\"}]"
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "protocol": "TCP",
+                        "port": 61616,
+                        "targetPort": 61616
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "broker-amq"
+                },
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "analytics-kieserver",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "analytics",
+                    "application": "migration-analytics",
+                    "rhdm": "1.0",
+                    "service": "analytics-kieserver",
+                    "template": "rhdm73-authoring"
+                },
+                "annotations": {
+                    "description": "All the KIE server web server's ports."
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "http",
+                        "protocol": "TCP",
+                        "port": 8080,
+                        "targetPort": 8080
+                    },
+                    {
+                        "name": "https",
+                        "protocol": "TCP",
+                        "port": 8443,
+                        "targetPort": 8443
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "analytics-kieserver"
+                },
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "analytics-rhdmcentr",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "analytics",
+                    "application": "migration-analytics",
+                    "rhdm": "1.0",
+                    "service": "analytics-rhdmcentr",
+                    "template": "rhdm73-authoring"
+                },
+                "annotations": {
+                    "description": "All the Decision Central web server's ports."
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "http",
+                        "protocol": "TCP",
+                        "port": 8080,
+                        "targetPort": 8080
+                    },
+                    {
+                        "name": "https",
+                        "protocol": "TCP",
+                        "port": 8443,
+                        "targetPort": 8443
+                    },
+                    {
+                        "name": "git-ssh",
+                        "protocol": "TCP",
+                        "port": 8001,
+                        "targetPort": 8001
+                    }
+                ],
+                "selector": {
+                    "deploymentConfig": "analytics-rhdmcentr"
+                },
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${DATABASE_SERVICE_NAME}",
+                "annotations": {
+                    "template.openshift.io/expose-uri": "postgres://{.spec.clusterIP}:{.spec.ports[?(.name==\"postgresql\")].port}"
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "postgresql",
+                        "protocol": "TCP",
+                        "port": 5432,
+                        "targetPort": 5432,
+                        "nodePort": 0
+                    }
+                ],
+                "selector": {
+                    "name": "${DATABASE_SERVICE_NAME}"
+                },
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "Service",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "xavier",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "xavier-http",
+                    "application": "migration-analytics",
+                    "service": "xavier"
+                },
+                "annotations": {
+                    "description": "The web server's http port."
+                }
+            },
+            "spec": {
+                "ports": [
+                    {
+                        "name": "http",
+                        "protocol": "TCP",
+                        "port": 8080,
+                        "targetPort": 8080
+                    }
+                ],
+                "selector": {
+                    "deploymentconfig": "analytics-integration"
+                },
+                "type": "ClusterIP",
+                "sessionAffinity": "None"
+            },
+            "status": {
+                "loadBalancer": {}
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "image.openshift.io/v1",
+            "metadata": {
+                "name": "analytics-integration",
+                "generation": 1,
+                "labels": {
+                    "app": "analytics-integration",
+                    "application": "migration-analytics",
+                    "component": "analytics-integration",
+                    "provider": "s2i",
+                    "template": "analytics-integration",
+                    "version": "1.0.0.fuse-730046-redhat-00002"
+                }
+            },
+            "status": {
+                "dockerImageRepository": ""
+            }
+        },
+        {
+            "kind": "PersistentVolumeClaim",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "analytics-rhdmcentr-claim",
+                "labels": {
+                    "app": "analytics",
+                    "application": "migration-analytics",
+                    "rhdm": "1.0",
+                    "service": "analytics-rhdmcentr",
+                    "template": "rhdm73-authoring"
+                }
+            },
+            "spec": {
+                "accessModes": [
+                    "ReadWriteMany"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "1Gi"
+                    }
+                }
+            }
+        },
+        {
+            "kind": "PersistentVolumeClaim",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${DATABASE_SERVICE_NAME}",
+                "labels": {
+                    "app": "${DATABASE_SERVICE_NAME}-persistent",
+                    "application": "migration-analytics"
+                }
+            },
+            "spec": {
+                "accessModes": [
+                    "ReadWriteOnce"
+                ],
+                "resources": {
+                    "requests": {
+                        "storage": "${DATABASE_VOLUME_CAPACITY}"
+                    }
+                }
+            }
+        },
+        {
+            "kind": "ServiceAccount",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "myapp-rhdmsvc",
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "analytics",
+                    "application": "migration-analytics",
+                    "rhdm": "1.0",
+                    "template": "rhdm73-authoring"
+                }
+            }
+        },
+        {
+            "kind": "BuildConfig",
+            "apiVersion": "build.openshift.io/v1",
+            "metadata": {
+                "name": "analytics-integration",
+                "labels": {
+                    "app": "analytics-integration",
+                    "application": "migration-analytics",
+                    "component": "analytics-integration",
+                    "provider": "s2i",
+                    "template": "analytics-integration",
+                    "version": "1.0.0.fuse-730046-redhat-00002"
+                }
+            },
+            "spec": {
+                "triggers": [
+                    {
+                        "type": "ImageChange",
+                        "imageChange": {}
+                    },
+                    {
+                        "type": "ConfigChange"
+                    },
+                    {
+                        "type": "GitHub",
+                        "github": {
+                            "secret": "jpFfohWRXRpCyjKOJa6e3PCLqs3BTJCFrn6ND6T5"
+                        }
+                    },
+                    {
+                        "type": "Generic",
+                        "generic": {
+                            "secret": "jpFfohWRXRpCyjKOJa6e3PCLqs3BTJCFrn6ND6T5"
+                        }
+                    }
+                ],
+                "runPolicy": "Serial",
+                "source": {
+                    "type": "Git",
+                    "git": {
+                        "uri": "https://github.com/project-xavier/xavier-integration.git",
+                        "ref": "master"
+                    }
+                },
+                "strategy": {
+                    "type": "Source",
+                    "sourceStrategy": {
+                        "from": {
+                            "kind": "ImageStreamTag",
+                            "namespace": "${NAMESPACE}",
+                            "name": "fuse7-java-openshift:1.3"
+                        },
+                        "env": [
+                            {
+                                "name": "BUILD_LOGLEVEL",
+                                "value": "5"
+                            },
+                            {
+                                "name": "ARTIFACT_DIR"
+                            },
+                            {
+                                "name": "MAVEN_ARGS",
+                                "value": "package -DskipTests -Dfabric8.skip -e -B"
+                            },
+                            {
+                                "name": "MAVEN_ARGS_APPEND"
+                            }
+                        ],
+                        "incremental": true,
+                        "forcePull": true
+                    }
+                },
+                "output": {
+                    "to": {
+                        "kind": "ImageStreamTag",
+                        "name": "analytics-integration:latest"
+                    }
+                },
+                "resources": {
+                    "limits": {
+                        "memory": "800M"
+                    },
+                    "requests": {
+                        "memory": "700M"
+                    }
+                },
+                "postCommit": {},
+                "nodeSelector": null,
+                "successfulBuildsHistoryLimit": 5,
+                "failedBuildsHistoryLimit": 5
+            },
+            "status": {
+                "lastVersion": 0
+            }
+        }
+    ],
+    "parameters": [
+        {
+            "name": "POSTGRESQL_MEMORY_LIMIT",
+            "displayName": "Database Memory Limit",
+            "description": "Database maximum amount of memory the container can use.",
+            "value": "512Mi",
+            "required": true
+        },
+        {
+            "name": "NAMESPACE",
+            "displayName": "Namespace",
+            "description": "The OpenShift Namespace where the ImageStream resides.",
+            "value": "openshift"
+        },
+        {
+            "name": "DATABASE_SERVICE_NAME",
+            "displayName": "Database Service Name",
+            "description": "The name of the OpenShift Service exposed for the database.",
+            "value": "postgresql",
+            "required": true
+        },
+        {
+            "name": "POSTGRESQL_USER",
+            "displayName": "PostgreSQL Connection Username",
+            "description": "Username for PostgreSQL user that will be used for accessing the database.",
+            "generate": "expression",
+            "from": "user[A-Z0-9]{3}",
+            "required": true
+        },
+        {
+            "name": "POSTGRESQL_PASSWORD",
+            "displayName": "PostgreSQL Connection Password",
+            "description": "Password for the PostgreSQL connection user.",
+            "generate": "expression",
+            "from": "[a-zA-Z0-9]{16}",
+            "required": true
+        },
+        {
+            "name": "POSTGRESQL_DATABASE",
+            "displayName": "PostgreSQL Database Name",
+            "description": "Name of the PostgreSQL database accessed.",
+            "value": "migration-analytics",
+            "required": true
+        },
+        {
+            "name": "DATABASE_VOLUME_CAPACITY",
+            "displayName": "Database Volume Capacity",
+            "description": "Database volume space available for data, e.g. 512Mi, 2Gi.",
+            "value": "1Gi",
+            "required": true
+        },
+        {
+            "name": "POSTGRESQL_VERSION",
+            "displayName": "Version of PostgreSQL Image",
+            "description": "Version of PostgreSQL image to be used.",
+            "value": "9.6",
+            "required": true
+        },
+        {
+            "name": "INSIGHTS_KAFKA_HOST",
+            "displayName": "AMQ Streams (Kafka) host",
+            "description": "AMQ Streams (Kafka) host",
+            "value": "platform-mq-ci-kafka-bootstrap.platform-mq-ci.svc:9092",
+            "required": true
+        }
+    ]
+}

--- a/src/main/resources/okd/analytics_template_insights_ci.json
+++ b/src/main/resources/okd/analytics_template_insights_ci.json
@@ -519,7 +519,7 @@
                                         "memory": "2Gi"
                                     },
                                     "requests": {
-                                        "cpu": "600m",
+                                        "cpu": "400m",
                                         "memory": "2Gi"
                                     }
                                 },
@@ -876,7 +876,7 @@
                                         "cpu": "1"
                                     },
                                     "requests": {
-                                        "cpu": "600m",
+                                        "cpu": "400m",
                                         "memory": "2Gi"
                                     }
                                 },


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-2392
Set of basic changes to have the prototype to work in Insights CI environment:

- added some routes' ID to help in debugging (auto-generated `route#` IDs where not so useful)
- added Kafka route to log the validation messages
- added `@JsonIgnoreProperties` annotation to `RHIdentity` in order to avoid the exception `com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "user" (class org.jboss.xavier.integrations.route.model.RHIdentity), not marked as ignorable (2 known properties: "account_number", "internal"])`
- added a new filter approach for kafka messages to avoid a NPE during base64 decoding of `b64_identity` value when it's missing (it happend with a message from `service=compliance`)
- added/changed some properties
- added a new `analytics_template_insights_ci.json` OCP template
- added some labels to have the delete command to work using label
- changed accordingly the README
