### PR TITLE
MIGENG-184 WS Report skeleton routes and tests

### DIFF
--- a/src/main/java/org/jboss/xavier/analytics/pojo/output/AnalysisModel.java
+++ b/src/main/java/org/jboss/xavier/analytics/pojo/output/AnalysisModel.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
+import org.jboss.xavier.analytics.pojo.output.workload.summary.WorkloadSummaryReportModel;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -37,6 +38,10 @@ public class AnalysisModel
     @OneToMany(mappedBy = "analysis", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     @JsonIgnore
     private List<WorkloadInventoryReportModel> workloadInventoryReportModels;
+
+    @OneToOne(mappedBy = "analysis", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JsonIgnore
+    private WorkloadSummaryReportModel workloadSummaryReportModels;
 
     private String reportName;
     private String reportDescription;
@@ -124,5 +129,13 @@ public class AnalysisModel
 
     public void setLastUpdate(Date lastUpdate) {
         this.lastUpdate = lastUpdate;
+    }
+
+    public WorkloadSummaryReportModel getWorkloadSummaryReportModels() {
+        return workloadSummaryReportModels;
+    }
+
+    public void setWorkloadSummaryReportModels(WorkloadSummaryReportModel workloadSummaryReportModels) {
+        this.workloadSummaryReportModels = workloadSummaryReportModels;
     }
 }

--- a/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/summary/SummaryModel.java
+++ b/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/summary/SummaryModel.java
@@ -1,0 +1,129 @@
+package org.jboss.xavier.analytics.pojo.output.workload.summary;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import javax.persistence.ColumnResult;
+import javax.persistence.ConstructorResult;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedNativeQuery;
+import javax.persistence.SqlResultSetMapping;
+
+@SqlResultSetMapping(
+        name = "mappingSummaryModels",
+        classes = @ConstructorResult(
+                targetClass = SummaryModel.class,
+                columns = {
+                        @ColumnResult(name = "provider", type = String.class),
+                        @ColumnResult(name = "clusters", type = Integer.class),
+                        @ColumnResult(name = "sockets", type = Long.class),
+                        @ColumnResult(name = "vms", type = Integer.class)
+                }
+        )
+)
+
+@NamedNativeQuery(
+        name = "SummaryModel.calculateSummaryModels",
+        query = "select provider, count(distinct cluster) as clusters, sum(cpu_cores)*2 as sockets, count(*) as vms from workload_inventory_report_model  where analysis_id = :analysisId group by provider order by provider;",
+        resultSetMapping = "mappingSummaryModels"
+)
+
+@Entity
+public class SummaryModel
+{
+    @Id
+    @GeneratedValue(strategy = javax.persistence.GenerationType.AUTO, generator = "SUMMARYMODEL_ID_GENERATOR")
+    @GenericGenerator(
+            name = "SUMMARYMODEL_ID_GENERATOR",
+            strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+            parameters = {
+                    @Parameter(name = "sequence_name", value = "SUMMARYMODEL_SEQUENCE")
+            }
+    )
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id")
+    @JsonBackReference
+    private WorkloadSummaryReportModel report;
+
+    private String provider;
+    private Integer clusters;
+    private Long sockets;
+    private Integer vms;
+
+    public SummaryModel() {}
+
+    public SummaryModel(String provider, Integer clusters, Long sockets, Integer vms) {
+        this.provider = provider;
+        this.clusters = clusters;
+        this.sockets = sockets;
+        this.vms = vms;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public WorkloadSummaryReportModel getReport() {
+        return report;
+    }
+
+    public void setReport(WorkloadSummaryReportModel report) {
+        this.report = report;
+    }
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public Integer getClusters() {
+        return clusters;
+    }
+
+    public void setClusters(Integer clusters) {
+        this.clusters = clusters;
+    }
+
+    public Long getSockets() {
+        return sockets;
+    }
+
+    public void setSockets(Long sockets) {
+        this.sockets = sockets;
+    }
+
+    public Integer getVms() {
+        return vms;
+    }
+
+    public void setVms(Integer vms) {
+        this.vms = vms;
+    }
+
+    @Override
+    public String toString() {
+        return "SummaryModel{" +
+                "id=" + id +
+                ", report=" + report +
+                ", providers='" + provider + '\'' +
+                ", clusters=" + clusters +
+                ", sockets=" + sockets +
+                ", vms=" + vms +
+                '}';
+    }
+}

--- a/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/summary/WorkloadSummaryReportModel.java
+++ b/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/summary/WorkloadSummaryReportModel.java
@@ -1,0 +1,82 @@
+package org.jboss.xavier.analytics.pojo.output.workload.summary;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
+import org.springframework.stereotype.Component;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Entity
+@Transactional
+@Table(
+        indexes = {
+                @Index(name = "WorkloadSummaryReportModel_" +
+                        WorkloadSummaryReportModel.ANALYSIS_ID + "_index",
+                        columnList = WorkloadSummaryReportModel.ANALYSIS_ID, unique = false)
+        }
+)
+@Component
+public class WorkloadSummaryReportModel
+{
+    static final long serialVersionUID = 1L;
+    static final String ANALYSIS_ID = "analysis_id";
+
+    @Id
+    @GeneratedValue(strategy = javax.persistence.GenerationType.AUTO, generator = "WORKLOADSUMMARYREPORTMODEL_ID_GENERATOR")
+    @GenericGenerator(
+            name = "WORKLOADSUMMARYREPORTMODEL_ID_GENERATOR",
+            strategy = "org.hibernate.id.enhanced.SequenceStyleGenerator",
+            parameters = {
+                    @Parameter(name = "sequence_name", value = "WORKLOADSUMMARYREPORT_SEQUENCE")
+            }
+    )
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = ANALYSIS_ID)
+    @JsonBackReference
+    private AnalysisModel analysis;
+
+    @OneToMany(mappedBy = "report", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    private List<SummaryModel> summaryModels;
+
+    public WorkloadSummaryReportModel() {}
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public AnalysisModel getAnalysis() {
+        return analysis;
+    }
+
+    public void setAnalysis(AnalysisModel analysis) {
+        this.analysis = analysis;
+    }
+
+    public List<SummaryModel> getSummaryModels() {
+        return summaryModels;
+    }
+
+    public void setSummaryModels(List<SummaryModel> summaryModels) {
+        summaryModels.forEach(model -> model.setReport(this));
+        this.summaryModels = summaryModels;
+    }
+}

--- a/src/main/java/org/jboss/xavier/integrations/DecisionServerHelper.java
+++ b/src/main/java/org/jboss/xavier/integrations/DecisionServerHelper.java
@@ -48,20 +48,6 @@ public class DecisionServerHelper {
         return generateCommands(inputDataModel, "get InitialSavingsEstimationReports", "kiesession0");
     }
 
-    public UploadFormInputDataModel createSampleUploadFormInputDataModel()
-    {
-        UploadFormInputDataModel uploadFormInputDataModel = new UploadFormInputDataModel();
-        String customerId = Integer.toString(random.nextInt(99999999));
-        uploadFormInputDataModel.setCustomerId(customerId);
-        uploadFormInputDataModel.setFileName(format.format(new Date()) + "-" + customerId + "-payload.json");
-        uploadFormInputDataModel.setHypervisor(random.nextInt(99999));
-        uploadFormInputDataModel.setGrowthRatePercentage(0.05);
-        uploadFormInputDataModel.setYear1HypervisorPercentage(0.5);
-        uploadFormInputDataModel.setYear2HypervisorPercentage(0.3);
-        uploadFormInputDataModel.setYear3HypervisorPercentage(0.15);
-        return uploadFormInputDataModel;
-    }
-
     public BatchExecutionCommand generateCommands(Object insert, String retrieveQueryId, String kiseSessionId)
     {
         List<Command<?>> cmds = new ArrayList<Command<?>>();

--- a/src/main/java/org/jboss/xavier/integrations/jpa/repository/SummaryRepository.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/repository/SummaryRepository.java
@@ -11,5 +11,6 @@ import java.util.Set;
 @Repository
 public interface SummaryRepository  extends JpaRepository<SummaryModel, Long>
 {
+    // this name has to match the value after the '.' in the @NamedNativeQuery annotation
     List<SummaryModel> calculateSummaryModels(@Param("analysisId") Long analysisId);
 }

--- a/src/main/java/org/jboss/xavier/integrations/jpa/repository/SummaryRepository.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/repository/SummaryRepository.java
@@ -1,0 +1,15 @@
+package org.jboss.xavier.integrations.jpa.repository;
+
+import org.jboss.xavier.analytics.pojo.output.workload.summary.SummaryModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Set;
+
+@Repository
+public interface SummaryRepository  extends JpaRepository<SummaryModel, Long>
+{
+    List<SummaryModel> calculateSummaryModels(@Param("analysisId") Long analysisId);
+}

--- a/src/main/java/org/jboss/xavier/integrations/jpa/repository/WorkloadSummaryReportRepository.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/repository/WorkloadSummaryReportRepository.java
@@ -1,0 +1,11 @@
+package org.jboss.xavier.integrations.jpa.repository;
+
+import org.jboss.xavier.analytics.pojo.output.workload.summary.WorkloadSummaryReportModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface WorkloadSummaryReportRepository extends JpaRepository<WorkloadSummaryReportModel, Long>
+{
+    WorkloadSummaryReportModel findByAnalysisId(Long analysisId);
+}

--- a/src/main/java/org/jboss/xavier/integrations/jpa/service/AnalysisService.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/service/AnalysisService.java
@@ -3,6 +3,7 @@ package org.jboss.xavier.integrations.jpa.service;
 import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
 import org.jboss.xavier.analytics.pojo.output.InitialSavingsEstimationReportModel;
 import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
+import org.jboss.xavier.analytics.pojo.output.workload.summary.WorkloadSummaryReportModel;
 import org.jboss.xavier.integrations.jpa.repository.AnalysisRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -44,14 +45,21 @@ public class AnalysisService
     public void setInitialSavingsEstimationReportModel(InitialSavingsEstimationReportModel reportModel, Long id) {
         AnalysisModel analysisModel = findById(id);
         analysisModel.setInitialSavingsEstimationReportModel(reportModel);
-        // TODO remove this since it's just a temporary workaround to change the status
-        analysisModel.setStatus("CREATED");
         analysisRepository.save(analysisModel);
     }
 
     public void addWorkloadInventoryReportModel(WorkloadInventoryReportModel reportModel, Long id) {
         AnalysisModel analysisModel = findById(id);
         analysisModel.addWorkloadInventoryReportModel(reportModel);
+        analysisRepository.save(analysisModel);
+    }
+
+    public void setWorkloadSummaryReportModel(WorkloadSummaryReportModel reportModel, Long id) {
+        AnalysisModel analysisModel = findById(id);
+        analysisModel.setWorkloadSummaryReportModels(reportModel);
+        reportModel.setAnalysis(analysisModel);
+        // TODO remove this since it's just a temporary workaround to change the status
+        analysisModel.setStatus("CREATED");
         analysisRepository.save(analysisModel);
     }
 

--- a/src/main/java/org/jboss/xavier/integrations/jpa/service/SummaryService.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/service/SummaryService.java
@@ -1,0 +1,20 @@
+package org.jboss.xavier.integrations.jpa.service;
+
+import org.jboss.xavier.analytics.pojo.output.workload.summary.SummaryModel;
+import org.jboss.xavier.integrations.jpa.repository.SummaryRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class SummaryService
+{
+    @Autowired
+    SummaryRepository summaryRepository;
+
+    public List<SummaryModel> calculateSummaryModels(Long analysisId)
+    {
+        return summaryRepository.calculateSummaryModels(analysisId);
+    }
+}

--- a/src/main/java/org/jboss/xavier/integrations/jpa/service/WorkloadSummaryReportService.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/service/WorkloadSummaryReportService.java
@@ -1,0 +1,18 @@
+package org.jboss.xavier.integrations.jpa.service;
+
+import org.jboss.xavier.analytics.pojo.output.workload.summary.WorkloadSummaryReportModel;
+import org.jboss.xavier.integrations.jpa.repository.WorkloadSummaryReportRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WorkloadSummaryReportService
+{
+    @Autowired
+    WorkloadSummaryReportRepository reportRepository;
+
+    public WorkloadSummaryReportModel findByAnalysisId(Long analysisId)
+    {
+        return reportRepository.findByAnalysisId(analysisId);
+    }
+}

--- a/src/main/java/org/jboss/xavier/integrations/route/VMWorkloadInventoryRoutes.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/VMWorkloadInventoryRoutes.java
@@ -3,21 +3,28 @@ package org.jboss.xavier.integrations.route;
 import org.apache.camel.builder.RouteBuilder;
 import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
 import org.jboss.xavier.integrations.jpa.service.AnalysisService;
+import org.jboss.xavier.integrations.jpa.service.WorkloadInventoryReportService;
 import org.jboss.xavier.integrations.migrationanalytics.business.VMWorkloadInventoryCalculator;
 
+import java.util.List;
+import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
-import java.util.Map;
 
 @Named
 public class VMWorkloadInventoryRoutes extends RouteBuilder {
-   @Inject
+
+    @Inject
     AnalysisService analysisService;
 
     @Override
     public void configure() {
         from("direct:calculate-vmworkloadinventory")
                 .id("calculate-vmworkloadinventory")
+                .onCompletion().onCompleteOnly()
+                .id("onCompletion-vmworkloadinventory")
+                .to("direct:aggregate-vmworkloadinventory")
+                .end()
                 .doTry()
                     .transform().method(VMWorkloadInventoryCalculator.class, "calculate(${body}, ${header.MA_metadata})")
                     .split(body())
@@ -30,7 +37,6 @@ public class VMWorkloadInventoryRoutes extends RouteBuilder {
 
         from ("jms:queue:vm-workload-inventory").id("extract-vmworkloadinventory")
             .to("log:INFO?showBody=true&showHeaders=true")
-//            .setHeader(MainRouteBuilder.ANALYSIS_ID, simple("${body.analysisId}"))
             .setHeader(MainRouteBuilder.ANALYSIS_ID, simple("${body." + MainRouteBuilder.ANALYSIS_ID + "}"))
             .transform().method("decisionServerHelper", "generateCommands(${body}, \"GetWorkloadInventoryReports\", \"WorkloadInventoryKSession0\")")
             .to("direct:decisionserver").id("workload-decisionserver")

--- a/src/main/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes.java
@@ -1,0 +1,75 @@
+package org.jboss.xavier.integrations.route;
+
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.builder.RouteBuilder;
+import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
+import org.jboss.xavier.analytics.pojo.output.workload.summary.SummaryModel;
+import org.jboss.xavier.analytics.pojo.output.workload.summary.WorkloadSummaryReportModel;
+import org.jboss.xavier.integrations.jpa.service.AnalysisService;
+import org.jboss.xavier.integrations.jpa.service.SummaryService;
+import org.jboss.xavier.integrations.jpa.service.WorkloadInventoryReportService;
+import org.springframework.beans.factory.annotation.Value;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+@Named
+public class WorkloadSummaryReportRoutes extends RouteBuilder {
+
+    private final Logger logger = Logger.getLogger(WorkloadSummaryReportRoutes.class.getName());
+
+    @Inject
+    WorkloadInventoryReportService workloadInventoryReportService;
+
+    @Inject
+    SummaryService summaryService;
+
+    @Inject
+    AnalysisService analysisService;
+
+    @Value("${report.workload.summary.polling.delay}")
+    private long delay;
+
+    @Value("${report.workload.summary.polling.max-attempts}")
+    private long maxAttempts;
+
+    @Override
+    public void configure() {
+
+        from("direct:aggregate-vmworkloadinventory")
+            .id("aggregate-vmworkloadinventory")
+            .process(exchange -> {
+                Integer expectedSize = ((Collection) exchange.getIn().getBody()).size();
+                String analysisId = ((Map<String, String>) exchange.getIn().getHeader("MA_metadata")).get(MainRouteBuilder.ANALYSIS_ID);
+                List<WorkloadInventoryReportModel> workloadInventoryReportModels  = workloadInventoryReportService.findByAnalysisId(Long.parseLong(analysisId));
+                int attempts = 0;
+                for (; workloadInventoryReportModels.size() < expectedSize && attempts < maxAttempts; attempts++)
+                {
+                    Thread.sleep(delay);
+                    logger.warning("workloadInventoryReportModels.size() < expectedSize since " + workloadInventoryReportModels.size()  + " < " + expectedSize);
+                    workloadInventoryReportModels  = workloadInventoryReportService.findByAnalysisId(Long.parseLong(analysisId));
+                }
+                if (maxAttempts == attempts) throw new CamelExecutionException("Unable to find the expected " + expectedSize + " WorkloadInventoryReportModels in the DB", exchange);
+            })
+            .to("direct:calculate-workloadsummaryreportmodel");
+
+        from("direct:calculate-workloadsummaryreportmodel")
+            .id("calculate-workloadsummaryreportmodel")
+            .process(exchange -> {
+                Long analysisId = Long.parseLong(((Map<String, String>) exchange.getIn().getHeader("MA_metadata")).get(MainRouteBuilder.ANALYSIS_ID));
+                List<SummaryModel> summaryModels = summaryService.calculateSummaryModels(analysisId);
+                // TODO Calculate the other parts of the Workload Summary Report
+
+                // Set the components into the WorkloadSummaryReportModel bean
+                WorkloadSummaryReportModel workloadSummaryReportModel = new WorkloadSummaryReportModel();
+                workloadSummaryReportModel.setSummaryModels(summaryModels);
+                // Set the WorkloadSummaryReportModel into the AnalysisModel
+                analysisService.setWorkloadSummaryReportModel(workloadSummaryReportModel, analysisId);
+            })
+            .to("log:INFO?showBody=true&showHeaders=true");
+    }
+}

--- a/src/main/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes.java
@@ -49,8 +49,8 @@ public class WorkloadSummaryReportRoutes extends RouteBuilder {
                 int attempts = 0;
                 for (; workloadInventoryReportModels.size() < expectedSize && attempts < maxAttempts; attempts++)
                 {
-                    Thread.sleep(delay);
                     logger.warning("workloadInventoryReportModels.size() < expectedSize since " + workloadInventoryReportModels.size()  + " < " + expectedSize);
+                    Thread.sleep(delay);
                     workloadInventoryReportModels  = workloadInventoryReportService.findByAnalysisId(Long.parseLong(analysisId));
                 }
                 if (maxAttempts == attempts) throw new CamelExecutionException("Unable to find the expected " + expectedSize + " WorkloadInventoryReportModels in the DB", exchange);
@@ -61,15 +61,18 @@ public class WorkloadSummaryReportRoutes extends RouteBuilder {
             .id("calculate-workloadsummaryreportmodel")
             .process(exchange -> {
                 Long analysisId = Long.parseLong(((Map<String, String>) exchange.getIn().getHeader("MA_metadata")).get(MainRouteBuilder.ANALYSIS_ID));
-                List<SummaryModel> summaryModels = summaryService.calculateSummaryModels(analysisId);
-                // TODO Calculate the other parts of the Workload Summary Report
-
-                // Set the components into the WorkloadSummaryReportModel bean
                 WorkloadSummaryReportModel workloadSummaryReportModel = new WorkloadSummaryReportModel();
+
+                //retrieve each model one after the other
+                List<SummaryModel> summaryModels = summaryService.calculateSummaryModels(analysisId);
+                // Set the components into the WorkloadSummaryReportModel bean
                 workloadSummaryReportModel.setSummaryModels(summaryModels);
+
+                // TODO Calculate the other parts of the Workload Summary Report
+                // and set them into the workloadSummaryReportModel bean
+
                 // Set the WorkloadSummaryReportModel into the AnalysisModel
                 analysisService.setWorkloadSummaryReportModel(workloadSummaryReportModel, analysisId);
-            })
-            .to("log:INFO?showBody=true&showHeaders=true");
+            });
     }
 }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -12,3 +12,4 @@ insights.properties=dummy
 
 spring.datasource.url = jdbc:h2:mem:test
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.H2Dialect
+spring.jpa.show-sql=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -88,5 +88,9 @@ cloudforms.manifest.v1.vmworkloadinventory.filesContentPath=$.ManageIQ::Provider
 cloudforms.manifest.v1.vmworkloadinventory.filesContentPathName=name
 cloudforms.manifest.v1.vmworkloadinventory.filesContentPathContents=contents
 
+# the workload summary waits for 10 minutes for the workload inventory beans to be persisted in the db
+report.workload.summary.polling.delay=5000
+report.workload.summary.polling.max-attempts=120
+
 # to be removed
 rest.user.value=false

--- a/src/main/resources/spring/camel-context.xml
+++ b/src/main/resources/spring/camel-context.xml
@@ -115,6 +115,12 @@
                     </setHeader>
                 </route>
             </get>
+            <get uri="/{id}/workload-summary">
+                <description>Get the Workload Summary Report</description>
+                <route id="workload-summary-report-get">
+                    <bean ref="workloadSummaryReportService" method="findByAnalysisId(${header.id})" />
+                </route>
+            </get>
         </rest>
 
         <rest path="/user">
@@ -143,14 +149,6 @@
             <bean id="route-extract-reports" method="extractReports" ref="decisionServerHelper"/>
             <log id="route-log-totalPrice" message="totalPrice = ${body.totalPrice}"/>
             <to uri="jpa:org.jboss.xavier.integrations.migrationanalytics.output.ReportDataModel" />
-        </route>
-
-        <route id="sample-uploadFormInputDataModel-generator" autoStartup="{{sig.autoStartup}}">
-            <description>Example route that will regularly create an InputDataModel and send it to a JMS queue</description>
-            <from id="route-timer" uri="timer:testRoute?period=10s" />
-            <bean id="route-new-uploadFormInputDataModel" method="createSampleUploadFormInputDataModel" ref="decisionServerHelper" />
-            <to id="route-to-new-jms" uri="jms:queue:uploadFormInputDataModel" />
-            <log message="Message with sample UploadFormInputDataModel sent" />
         </route>
 
         <route id="route-ma">

--- a/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectAggregateVMWorkloadInventoryModelTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectAggregateVMWorkloadInventoryModelTest.java
@@ -1,0 +1,107 @@
+package org.jboss.xavier.integrations.route;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringBootRunner;
+import org.apache.camel.test.spring.MockEndpointsAndSkip;
+import org.apache.camel.test.spring.UseAdviceWith;
+import org.jboss.xavier.Application;
+import org.jboss.xavier.analytics.pojo.input.workload.inventory.VMWorkloadInventoryModel;
+import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
+import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
+import org.jboss.xavier.analytics.pojo.output.workload.summary.WorkloadSummaryReportModel;
+import org.jboss.xavier.integrations.jpa.repository.AnalysisRepository;
+import org.jboss.xavier.integrations.jpa.repository.WorkloadInventoryReportRepository;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(CamelSpringBootRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@MockEndpointsAndSkip("direct:calculate-workloadsummaryreportmodel")
+@UseAdviceWith // Disables automatic start of Camel context
+@SpringBootTest(classes = {Application.class})
+@ActiveProfiles("test")
+public class WorkloadSummaryReportRoutes_DirectAggregateVMWorkloadInventoryModelTest {
+    @Inject
+    CamelContext camelContext;
+
+    @EndpointInject(uri = "mock:direct:calculate-workloadsummaryreportmodel")
+    private MockEndpoint mockCalculateVMWorkloadInventoryModel;
+
+    @Autowired
+    WorkloadInventoryReportRepository workloadInventoryReportRepository;
+
+    @Autowired
+    AnalysisRepository analysisRepository;
+
+    private Long analysisId;
+
+    @Before
+    public void setup()
+    {
+        AnalysisModel analysisModel = new AnalysisModel();
+        analysisModel = analysisRepository.save(analysisModel);
+        analysisId = analysisModel.getId();
+    }
+
+    @Test
+    public void DirectAggregateVMWorkloadInventoryModel_ShouldWaitForWorkloadInventoryReportModelInTheDB() throws Exception {
+        //Given
+        camelContext.setTracing(true);
+        camelContext.setAutoStartup(false);
+
+        //When
+        camelContext.start();
+        camelContext.startRoute("aggregate-vmworkloadinventory");
+
+        int collectionSize = 4;
+        Collection<VMWorkloadInventoryModel> vmWorkloadInventoryModels = new ArrayList<>(collectionSize);
+        IntStream.range(0, collectionSize).forEach(value -> vmWorkloadInventoryModels.add(new VMWorkloadInventoryModel()));
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(MainRouteBuilder.ANALYSIS_ID, analysisId.toString());
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("MA_metadata", metadata);
+
+        CompletableFuture<Object> responseFuture = camelContext.createProducerTemplate().asyncRequestBodyAndHeaders("direct:aggregate-vmworkloadinventory", vmWorkloadInventoryModels, headers);
+
+        AnalysisModel analysisModel = new AnalysisModel();
+        analysisModel.setId(analysisId);
+        IntStream.range(0, collectionSize).forEach(value -> {
+            try {
+                Thread.sleep(7000);
+                WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+                workloadInventoryReportModel.setAnalysis(analysisModel);
+                System.out.println("Saved WorkloadInventoryReportModel with ID #" + workloadInventoryReportRepository.save(workloadInventoryReportModel).getId());
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+
+        //Then
+        Object response = responseFuture.join();
+        assertThat(response).isInstanceOf(Collection.class);
+        assertThat(mockCalculateVMWorkloadInventoryModel.getExchanges().size()).isEqualTo(1);
+
+        camelContext.stop();
+    }
+
+}

--- a/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectAggregateVMWorkloadInventoryModelTest_ThrowException.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectAggregateVMWorkloadInventoryModelTest_ThrowException.java
@@ -1,0 +1,97 @@
+package org.jboss.xavier.integrations.route;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.CamelExecutionException;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringBootRunner;
+import org.apache.camel.test.spring.MockEndpointsAndSkip;
+import org.apache.camel.test.spring.UseAdviceWith;
+import org.jboss.xavier.Application;
+import org.jboss.xavier.analytics.pojo.input.workload.inventory.VMWorkloadInventoryModel;
+import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
+import org.jboss.xavier.integrations.jpa.repository.AnalysisRepository;
+import org.jboss.xavier.integrations.jpa.repository.WorkloadInventoryReportRepository;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.core.Is.isA;
+
+@RunWith(CamelSpringBootRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@MockEndpointsAndSkip("direct:calculate-workloadsummaryreportmodel")
+@UseAdviceWith // Disables automatic start of Camel context
+@SpringBootTest(classes = {Application.class})
+@ActiveProfiles("test")
+@TestPropertySource(properties = {"report.workload.summary.polling.delay=50","report.workload.summary.polling.max-attempts=10"})
+public class WorkloadSummaryReportRoutes_DirectAggregateVMWorkloadInventoryModelTest_ThrowException {
+    @Inject
+    CamelContext camelContext;
+
+    @EndpointInject(uri = "mock:direct:calculate-workloadsummaryreportmodel")
+    private MockEndpoint mockCalculateVMWorkloadInventoryModel;
+
+    @Autowired
+    WorkloadInventoryReportRepository workloadInventoryReportRepository;
+
+    @Autowired
+    AnalysisRepository analysisRepository;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private Long analysisId;
+
+    @Before
+    public void setup()
+    {
+        AnalysisModel analysisModel = new AnalysisModel();
+        analysisModel = analysisRepository.save(analysisModel);
+        analysisId = analysisModel.getId();
+    }
+
+    @Test
+    public void DirectAggregateVMWorkloadInventoryModel_ShouldThrowException() throws Exception {
+        //Given
+        camelContext.setTracing(true);
+        camelContext.setAutoStartup(false);
+        expectedException.expectCause(isA(CamelExecutionException.class));
+        expectedException.expectMessage("Unable to find the expected");
+
+        //When
+        camelContext.start();
+        camelContext.startRoute("aggregate-vmworkloadinventory");
+
+        int collectionSize = 4;
+        Collection<VMWorkloadInventoryModel> vmWorkloadInventoryModels = new ArrayList<>(collectionSize);
+        IntStream.range(0, collectionSize).forEach(value -> vmWorkloadInventoryModels.add(new VMWorkloadInventoryModel()));
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(MainRouteBuilder.ANALYSIS_ID, analysisId.toString());
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("MA_metadata", metadata);
+
+        CompletableFuture<Object> responseFuture = camelContext.createProducerTemplate().asyncRequestBodyAndHeaders("direct:aggregate-vmworkloadinventory", vmWorkloadInventoryModels, headers);
+
+        //Then
+        Object response = responseFuture.join();
+        camelContext.stop();
+    }
+
+}

--- a/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModelTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModelTest.java
@@ -1,0 +1,111 @@
+package org.jboss.xavier.integrations.route;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.test.spring.CamelSpringBootRunner;
+import org.apache.camel.test.spring.UseAdviceWith;
+import org.jboss.xavier.Application;
+import org.jboss.xavier.analytics.pojo.input.workload.inventory.VMWorkloadInventoryModel;
+import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
+import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
+import org.jboss.xavier.analytics.pojo.output.workload.summary.SummaryModel;
+import org.jboss.xavier.analytics.pojo.output.workload.summary.WorkloadSummaryReportModel;
+import org.jboss.xavier.integrations.jpa.repository.AnalysisRepository;
+import org.jboss.xavier.integrations.jpa.repository.WorkloadInventoryReportRepository;
+import org.jboss.xavier.integrations.jpa.repository.WorkloadSummaryReportRepository;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+@RunWith(CamelSpringBootRunner.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@UseAdviceWith // Disables automatic start of Camel context
+@SpringBootTest(classes = {Application.class})
+@ActiveProfiles("test")
+public class WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModelTest {
+    @Inject
+    CamelContext camelContext;
+
+    @Autowired
+    WorkloadInventoryReportRepository workloadInventoryReportRepository;
+
+    @Autowired
+    AnalysisRepository analysisRepository;
+
+    @Autowired
+    WorkloadSummaryReportRepository workloadSummaryReportRepository;
+
+    private Long analysisId;
+    private int collectionSize = 6;
+
+    @Before
+    public void setup()
+    {
+        final AnalysisModel analysisModel = analysisRepository.save(new AnalysisModel());
+        analysisId = analysisModel.getId();
+        IntStream.range(0, collectionSize).forEach(value -> {
+            WorkloadInventoryReportModel workloadInventoryReportModel = new WorkloadInventoryReportModel();
+            workloadInventoryReportModel.setAnalysis(analysisModel);
+            workloadInventoryReportModel.setProvider("Provider" + (value % 2));
+            workloadInventoryReportModel.setCluster("Cluster" + (value % 3));
+            workloadInventoryReportModel.setCpuCores(value % 4);
+            System.out.println("Saved WorkloadInventoryReportModel with ID #" + workloadInventoryReportRepository.save(workloadInventoryReportModel).getId());
+        });
+    }
+
+    @Test
+    public void DirectCalculateVMWorkloadInventoryModel_ShouldPersistWorkloadSummaryReportModel() throws Exception {
+        //Given
+        camelContext.setTracing(true);
+        camelContext.setAutoStartup(false);
+
+        //When
+        camelContext.start();
+        camelContext.startRoute("calculate-workloadsummaryreportmodel");
+
+        Collection<VMWorkloadInventoryModel> vmWorkloadInventoryModels = new ArrayList<>(collectionSize);
+        IntStream.range(0, collectionSize).forEach(value -> vmWorkloadInventoryModels.add(new VMWorkloadInventoryModel()));
+
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(MainRouteBuilder.ANALYSIS_ID, analysisId.toString());
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("MA_metadata", metadata);
+
+        Exchange message = camelContext.createProducerTemplate().request("direct:calculate-workloadsummaryreportmodel", exchange -> {
+            exchange.getIn().setBody(vmWorkloadInventoryModels);
+            exchange.getIn().setHeaders(headers);
+        });
+
+        //Then
+        AnalysisModel analysisModel = analysisRepository.findOne(analysisId);
+        Assert.assertNotNull(analysisModel);
+        WorkloadSummaryReportModel workloadSummaryReportModel = analysisModel.getWorkloadSummaryReportModels();
+        Assert.assertNotNull(workloadSummaryReportModel);
+        workloadSummaryReportModel = workloadSummaryReportRepository.findOne(workloadSummaryReportModel.getId());
+        List<SummaryModel> summaryModels = workloadSummaryReportModel.getSummaryModels();
+        Assert.assertNotNull(summaryModels);
+        Assert.assertEquals("Provider0", summaryModels.get(0).getProvider());
+        Assert.assertEquals("Provider1", summaryModels.get(1).getProvider());
+        Assert.assertEquals(3, summaryModels.get(0).getClusters(), 0);
+        Assert.assertEquals(3, summaryModels.get(1).getClusters(), 0);
+        Assert.assertEquals(4L, summaryModels.get(0).getSockets(), 0);
+        Assert.assertEquals(10L, summaryModels.get(1).getSockets(), 0);
+        Assert.assertEquals(3, summaryModels.get(0).getVms(), 0);
+        Assert.assertEquals(3, summaryModels.get(1).getVms(), 0);
+
+        camelContext.stop();
+    }
+}

--- a/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
@@ -9,6 +9,7 @@ import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
 import org.jboss.xavier.integrations.jpa.service.AnalysisService;
 import org.jboss.xavier.integrations.jpa.service.InitialSavingsEstimationReportService;
 import org.jboss.xavier.integrations.jpa.service.WorkloadInventoryReportService;
+import org.jboss.xavier.integrations.jpa.service.WorkloadSummaryReportService;
 import org.jboss.xavier.integrations.route.model.PageBean;
 import org.jboss.xavier.integrations.route.model.SortBean;
 import org.junit.Assert;
@@ -56,6 +57,9 @@ public class XmlRoutes_RestReportTest {
 
     @SpyBean
     private AnalysisService analysisService;
+
+    @SpyBean
+    private WorkloadSummaryReportService workloadSummaryReportService;
 
     @Value("${camel.component.servlet.mapping.context-path}")
     String camel_context;
@@ -317,6 +321,29 @@ public class XmlRoutes_RestReportTest {
         Assert.assertTrue(response.getHeaders().get("Content-Disposition").contains("attachment;filename=workloadInventory_1.csv"));
         Assert.assertNull(response.getHeaders().get("whatever"));
         Assert.assertNotNull(response.getBody());
+        camelContext.stop();
+    }
+
+    @Test
+    public void xmlRouteBuilder_RestReportIdWorkloadSummary_IdParamGiven_ShouldCallFindByAnalysisId() throws Exception {
+        //Given
+        camelContext.setTracing(true);
+        camelContext.setAutoStartup(false);
+
+        //When
+        camelContext.start();
+        camelContext.startRoute("workload-summary-report-get");
+        Map<String, Object> variables = new HashMap<>();
+        Long analysisId = 11L;
+        variables.put("id", analysisId);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("whatever", "this header should not be copied");
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+        ResponseEntity<String> response = restTemplate.exchange(camel_context + "report/{id}/workload-summary" , HttpMethod.GET, entity, String.class, variables);
+
+        //Then
+        verify(workloadSummaryReportService).findByAnalysisId(analysisId);
+        Assert.assertNull(response.getHeaders().get("whatever"));
         camelContext.stop();
     }
 


### PR DESCRIPTION
### Issue
https://jira.coreos.com/browse/MIGENG-184
### Changes
- added the first version of the `WorkloadSummaryReportModel` with the `SummaryModel`
- the `SummaryModel` has `NamedNativeQuery` and `SqlResultSetMapping` to provide an example about how to create new bean for the boxes in the WSR with each one having its own query to be created
- the `SummaryRepository` has the declaration of the method to execute  the `SummaryModel.calculateSummaryModels` native query (the name follows a Spring convention)
- enhanced the `VMWorkloadInventoryRoutes.calculate-vmworkloadinventory` route so that once it finishes successfully (`.onCompletion().onCompleteOnly()`), it starts the `WorkloadSummaryReportRoutes.aggregate-vmworkloadinventory` route
- `VMWorkloadInventoryRoutes.calculate-vmworkloadinventory` route: i don't like it too much because i'm sure there's a better way to do it with Camel using, maybe, [JPA poller feauters](https://camel.apache.org/jpa.html) and [aggregator EIP](https://camel.apache.org/aggregator.html).  
Anyway it works and it can be controlled with 2 properties: 
   - `report.workload.summary.polling.delay` defines the time in milliseconds between each poll (default `5000`)
   - `report.workload.summary.polling.max-attempts` defines the max number of attempts before throwing an exception to avoid having a thread stuck in the pool loop (default `120`)  
   - So the poller waits for 5 minutes for all the expected `WorkloadInventoryReportModel` to be persisted in the DB
   - `WorkloadSummaryReportRoutes_DirectAggregateVMWorkloadInventoryModelTest` test persists `WorkloadInventoryReportModel` in the DB one after the other so the poller is tested 
   - `WorkloadSummaryReportRoutes_DirectAggregateVMWorkloadInventoryModelTest_ThrowException` test checks that the poller throws exactly the expected exception so that we're safe that there's no infinite poller loop
- added the `/report/{id}/workload-summary` REST endpoint
- removed some sample rules and method not used any more to avoid any further confusion

### Workflow to create a new bean for a box in the WSR
In order to create the code for the `Foo` box in the WSR, you need to:
1. copy&paste `SummaryModel.java` with name `FooModel.java`
1. add the needed fields to the bean
1. change the `@NamedNativeQuery` fields
1. change the `@SqlResultSetMapping` mapping
1. add the `FooModel` to the `WorkloadSummaryReportModel`
1. copy&paste the `SummaryRepository` with name `FooRepository`
1. add the method to the `FooRepository` that matches the `@NamedNativeQuery` annotation
1. copy&paste `SummaryService.java` with name `FooService.java`
1. add the method created early in the `FooRepository`
1. enhance the code in the `aggregate-vmworkloadinventory` route to execute the method and so the native query
1. enhance the `WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModelTest` to check the new `FooModel` has been persisted in the DB with the expected values