### PR TITLE
Fix: Workload Migration Inventory - search by FlagsIMS

### DIFF
--- a/src/main/java/org/jboss/xavier/integrations/jpa/repository/WorkloadInventoryReportSpecs.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/repository/WorkloadInventoryReportSpecs.java
@@ -103,7 +103,7 @@ public class WorkloadInventoryReportSpecs {
         }
 
         if (filterBean.getFlagsIMS() != null && !filterBean.getFlagsIMS().isEmpty()) {
-            specifications.add(getIsMemberSpecification("flagsIMS", filterBean.getRecommendedTargetsIMS()));
+            specifications.add(getIsMemberSpecification("flagsIMS", filterBean.getFlagsIMS()));
         }
 
         // union of specifications

--- a/src/main/java/org/jboss/xavier/integrations/route/ToBeanRouter.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/ToBeanRouter.java
@@ -130,6 +130,7 @@ public class ToBeanRouter extends RouteBuilder {
                         // store the reply from the bean on the OUT message
                         exchange.getOut().setHeaders(headers);
                         exchange.getOut().setBody(exchange.getIn().getBody());
+                        exchange.getOut().setAttachments(exchange.getIn().getAttachments());
                     }
                 });
     }


### PR DESCRIPTION
There is a java.lang.NullPointerException when searching by FlagsIMS. It is caused by an error in the source code which is fixed by this PR