### PR TITLE
hotfix-kafka-autooffset set autoOffsetReset to latest

### DIFF
--- a/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
@@ -121,7 +121,7 @@ public class MainRouteBuilder extends RouteBuilderExceptionHandler {
                         .throwException(org.apache.commons.httpclient.HttpException.class, "Unsuccessful response from Insights Upload Service")
                 .end();
 
-        from("kafka:" + kafkaHost + "?topic={{insights.kafka.upload.topic}}&brokers=" + kafkaHost + "&autoOffsetReset=earliest&autoCommitEnable=true")
+        from("kafka:" + kafkaHost + "?topic={{insights.kafka.upload.topic}}&brokers=" + kafkaHost + "&autoOffsetReset=latest&autoCommitEnable=true")
                 .routeId("kafka-upload-message")
                 .unmarshal().json(JsonLibrary.Jackson, FilePersistedNotification.class)
                 .filter(simple("'{{insights.service}}' == ${body.getService}"))


### PR DESCRIPTION
Restored the old value that this property had : autoOffsetReset=latest on the kafka camel component to avoid re consuming mensages from kafka and having duplications on DB