### PR TITLE
Analysis summary projection

### DIFF
--- a/src/main/java/org/jboss/xavier/integrations/jpa/projection/AnalysisSummary.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/projection/AnalysisSummary.java
@@ -1,0 +1,14 @@
+package org.jboss.xavier.integrations.jpa.projection;
+
+import java.util.Date;
+
+public interface AnalysisSummary
+{
+    Long getId();
+    String getReportName();
+    String getReportDescription();
+    String getPayloadName();
+    Date getInserted();
+    Date getLastUpdate();
+    String getStatus();
+}

--- a/src/main/java/org/jboss/xavier/integrations/jpa/repository/AnalysisRepository.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/repository/AnalysisRepository.java
@@ -19,6 +19,8 @@ public interface AnalysisRepository extends JpaRepository<AnalysisModel, Long>
 
     Page<AnalysisModel> findByOwnerAndReportNameIgnoreCaseContaining(String owner, String filterText, Pageable pageable);
 
+    Page<AnalysisSummary> findAnalysisSummaryByOwnerAndReportNameIgnoreCaseContaining(String owner, String filterText, Pageable pageable);
+
     Page<AnalysisModel> findAllByOwner(String owner, Pageable pageable);
 
     Page<AnalysisSummary> findAllAnalysisSummaryByOwner(String owner, Pageable pageable);

--- a/src/main/java/org/jboss/xavier/integrations/jpa/repository/AnalysisRepository.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/repository/AnalysisRepository.java
@@ -2,6 +2,7 @@ package org.jboss.xavier.integrations.jpa.repository;
 
 import org.jboss.xavier.analytics.pojo.AdministrationMetricsProjection;
 import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
+import org.jboss.xavier.integrations.jpa.projection.AnalysisSummary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,7 +21,11 @@ public interface AnalysisRepository extends JpaRepository<AnalysisModel, Long>
 
     Page<AnalysisModel> findAllByOwner(String owner, Pageable pageable);
 
+    Page<AnalysisSummary> findAllAnalysisSummaryByOwner(String owner, Pageable pageable);
+
     AnalysisModel findByOwnerAndId(String owner, Long id);
+
+    AnalysisSummary findAnalysisSummaryByOwnerAndId(String owner, Long id);
 
     Integer countByOwner(String owner);
 

--- a/src/main/java/org/jboss/xavier/integrations/jpa/service/AnalysisService.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/service/AnalysisService.java
@@ -126,6 +126,12 @@ public class AnalysisService
         return analysisRepository.findByOwnerAndReportNameIgnoreCaseContaining(owner, filterText.trim(), pageable);
     }
 
+    public Page<AnalysisSummary> findAnalysisSummaryByOwnerAndReportName(String owner, String filterText, int page, int size)
+    {
+        Pageable pageable = new PageRequest(page, size, new Sort(Sort.Direction.DESC, "id"));
+        return analysisRepository.findAnalysisSummaryByOwnerAndReportNameIgnoreCaseContaining(owner, filterText.trim(), pageable);
+    }
+
     public void updateStatus(String status, Long id) {
         AnalysisModel analysisModel = findById(id);
         analysisModel.setStatus(status);

--- a/src/main/java/org/jboss/xavier/integrations/jpa/service/AnalysisService.java
+++ b/src/main/java/org/jboss/xavier/integrations/jpa/service/AnalysisService.java
@@ -5,6 +5,7 @@ import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
 import org.jboss.xavier.analytics.pojo.output.InitialSavingsEstimationReportModel;
 import org.jboss.xavier.analytics.pojo.output.workload.inventory.WorkloadInventoryReportModel;
 import org.jboss.xavier.analytics.pojo.output.workload.summary.WorkloadSummaryReportModel;
+import org.jboss.xavier.integrations.jpa.projection.AnalysisSummary;
 import org.jboss.xavier.integrations.jpa.repository.AnalysisRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -40,6 +41,11 @@ public class AnalysisService
     public AnalysisModel findByOwnerAndId(String owner, Long id)
     {
         return analysisRepository.findByOwnerAndId(owner, id);
+    }
+
+    public AnalysisSummary findAnalysisSummaryByOwnerAndId(String owner, Long id)
+    {
+        return analysisRepository.findAnalysisSummaryByOwnerAndId(owner, id);
     }
 
     public void deleteById(Long id)
@@ -101,6 +107,12 @@ public class AnalysisService
     {
         Pageable pageable = new PageRequest(page, size, new Sort(Sort.Direction.DESC, "id"));
         return analysisRepository.findAllByOwner(owner, pageable);
+    }
+
+    public Page<AnalysisSummary> findAllAnalysisSummaryByOwner(String owner, int page, int size)
+    {
+        Pageable pageable = new PageRequest(page, size, new Sort(Sort.Direction.DESC, "id"));
+        return analysisRepository.findAllAnalysisSummaryByOwner(owner, pageable);
     }
 
     public Integer countByOwner(String owner)

--- a/src/main/resources/spring/camel-context.xml
+++ b/src/main/resources/spring/camel-context.xml
@@ -128,7 +128,7 @@
                 <route id="reports-get-all">
                     <choice>
                         <when>
-                            <simple>${header.filterText} == null</simple>
+                            <simple>${header.filterText} == null || ${header.filterText} == ''</simple>
                             <log message="No filterText parameter"/>
                             <bean ref="analysisService" method="findAllAnalysisSummaryByOwner(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.page}, ${header.size})" />
                         </when>

--- a/src/main/resources/spring/camel-context.xml
+++ b/src/main/resources/spring/camel-context.xml
@@ -129,10 +129,12 @@
                     <choice>
                         <when>
                             <simple>${header.filterText} == null</simple>
+                            <log message="No filterText parameter"/>
                             <bean ref="analysisService" method="findAllAnalysisSummaryByOwner(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.page}, ${header.size})" />
                         </when>
                         <otherwise>
-                            <bean ref="analysisService" method="findByOwnerAndReportName(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.filterText}, ${header.page}, ${header.size})" />
+                            <log message="With filterText parameter"/>
+                            <bean ref="analysisService" method="findAnalysisSummaryByOwnerAndReportName(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.filterText}, ${header.page}, ${header.size})" />
                         </otherwise>
                     </choice>
                 </route>

--- a/src/main/resources/spring/camel-context.xml
+++ b/src/main/resources/spring/camel-context.xml
@@ -129,11 +129,9 @@
                     <choice>
                         <when>
                             <simple>${header.filterText} == null || ${header.filterText} == ''</simple>
-                            <log message="No filterText parameter"/>
                             <bean ref="analysisService" method="findAllAnalysisSummaryByOwner(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.page}, ${header.size})" />
                         </when>
                         <otherwise>
-                            <log message="With filterText parameter"/>
                             <bean ref="analysisService" method="findAnalysisSummaryByOwnerAndReportName(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.filterText}, ${header.page}, ${header.size})" />
                         </otherwise>
                     </choice>

--- a/src/main/resources/spring/camel-context.xml
+++ b/src/main/resources/spring/camel-context.xml
@@ -129,7 +129,7 @@
                     <choice>
                         <when>
                             <simple>${header.filterText} == null</simple>
-                            <bean ref="analysisService" method="findAllByOwner(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.page}, ${header.size})" />
+                            <bean ref="analysisService" method="findAllAnalysisSummaryByOwner(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.page}, ${header.size})" />
                         </when>
                         <otherwise>
                             <bean ref="analysisService" method="findByOwnerAndReportName(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.filterText}, ${header.page}, ${header.size})" />
@@ -140,13 +140,13 @@
             <get uri="/{id}">
                 <description>Get the details of a report</description>
                 <route id="report-get-details">
-                    <bean ref="analysisService" method="findByOwnerAndId(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.id})" />
+                    <bean ref="analysisService" method="findAnalysisSummaryByOwnerAndId(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.id})" />
                 </route>
             </get>
             <delete uri="/{id}">
                 <description>Delete a report</description>
                 <route id="report-delete">
-                    <bean ref="analysisService" method="findByOwnerAndId(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.id})"/>
+                    <bean ref="analysisService" method="findAnalysisSummaryByOwnerAndId(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.id})"/>
                     <choice>
                         <when>
                             <simple>${body} != null</simple>
@@ -208,7 +208,7 @@
                 <description>Get available filters</description>
                 <route id="workload-inventory-report-available-filters">
                     <!-- if the user is the owner of the analysis then it's fine to get the filters -->
-                    <bean ref="analysisService" method="findByOwnerAndId(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.id})"/>
+                    <bean ref="analysisService" method="findAnalysisSummaryByOwnerAndId(${header.${type:org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler.USERNAME}}, ${header.id})"/>
                     <choice>
                         <when>
                             <simple>${body} != null</simple>

--- a/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
@@ -177,6 +177,35 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
     }
 
     @Test
+    public void xmlRouteBuilder_RestReport_FilterTextEmptyPageAndSizeParamGiven_ShouldCallFindReports() throws Exception {
+        //Given
+        //When
+        camelContext.start();
+        TestUtil.startUsernameRoutes(camelContext);
+        camelContext.startRoute("reports-get-all");
+        Map<String, Object> variables = new HashMap<>();
+        int page = 2;
+        variables.put("page", page);
+        int size = 3;
+        variables.put("size", size);
+        String filterText = "";
+        variables.put("filterText", filterText);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(TestUtil.HEADER_RH_IDENTITY, TestUtil.getBase64RHIdentity());
+        HttpEntity<String> entity = new HttpEntity<>(null, headers);
+
+        ResponseEntity<String> response = restTemplate.exchange(camel_context + "report?page={page}&size={size}&filterText={filterText}", HttpMethod.GET, entity, String.class, variables);
+
+        //Then
+        verify(analysisService).findAllAnalysisSummaryByOwner("mrizzi@redhat.com", page, size);
+        assertThat(response).isNotNull();
+        assertThat(response.getBody()).contains("\"content\":[]");
+        assertThat(response.getBody()).contains("\"size\":3");
+        camelContext.stop();
+    }
+
+    @Test
     public void xmlRouteBuilder_RestReportId_IdParamGiven_ShouldCallFindById() throws Exception {
         //Given
 

--- a/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
@@ -5,6 +5,7 @@ import org.apache.camel.builder.AdviceWithRouteBuilder;
 import org.apache.commons.io.IOUtils;
 import org.jboss.xavier.Application;
 import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
+import org.jboss.xavier.integrations.jpa.projection.AnalysisSummary;
 import org.jboss.xavier.integrations.jpa.service.AnalysisService;
 import org.jboss.xavier.integrations.jpa.service.FlagService;
 import org.jboss.xavier.integrations.jpa.service.InitialSavingsEstimationReportService;
@@ -34,6 +35,7 @@ import org.springframework.http.ResponseEntity;
 import javax.servlet.http.HttpServletResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -89,7 +91,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         ResponseEntity<String> response = restTemplate.exchange(camel_context + "report/", HttpMethod.GET, entity, String.class);
 
         //Then
-        verify(analysisService).findAllByOwner("mrizzi@redhat.com", 0, 10);
+        verify(analysisService).findAllAnalysisSummaryByOwner("mrizzi@redhat.com", 0, 10);
         assertThat(response).isNotNull();
         assertThat(response.getBody()).contains("\"content\":[]");
         assertThat(response.getBody()).contains("\"size\":10");
@@ -136,7 +138,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         ResponseEntity<String> response = restTemplate.exchange(camel_context + "report?page={page}&size={size}", HttpMethod.GET, entity, String.class, variables);
 
         //Then
-        verify(analysisService).findAllByOwner("mrizzi@redhat.com", page, size);
+        verify(analysisService).findAllAnalysisSummaryByOwner("mrizzi@redhat.com", page, size);
         assertThat(response).isNotNull();
         assertThat(response.getBody()).contains("\"content\":[]");
         assertThat(response.getBody()).contains("\"size\":3");
@@ -195,7 +197,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         ResponseEntity<String> response = restTemplate.exchange(camel_context + "report/{id}", HttpMethod.GET, entity, String.class, variables);
 
         //Then
-        verify(analysisService).findByOwnerAndId("mrizzi@redhat.com", one);
+        verify(analysisService).findAnalysisSummaryByOwnerAndId("mrizzi@redhat.com", one);
         assertThat(response).isNotNull();
         camelContext.stop();
     }
@@ -437,7 +439,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         //Given
 
         Long one = 1L;
-        when(analysisService.findByOwnerAndId("mrizzi@redhat.com", one)).thenReturn(null);
+        when(analysisService.findAnalysisSummaryByOwnerAndId("mrizzi@redhat.com", one)).thenReturn(null);
 
         //When
         camelContext.start();
@@ -454,7 +456,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
 
         //Then
         Assert.assertEquals(response.getStatusCodeValue(), HttpServletResponse.SC_NOT_FOUND);
-        verify(analysisService).findByOwnerAndId("mrizzi@redhat.com", one);
+        verify(analysisService).findAnalysisSummaryByOwnerAndId("mrizzi@redhat.com", one);
         verify(analysisService, never()).deleteById(one);
         assertThat(response).isNotNull();
         assertThat(response.getBody()).contains("Analysis not found");
@@ -466,7 +468,42 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         //Given
 
         Long one = 1L;
-        when(analysisService.findByOwnerAndId("mrizzi@redhat.com",one)).thenReturn(new AnalysisModel());
+        when(analysisService.findAnalysisSummaryByOwnerAndId("mrizzi@redhat.com",one)).thenReturn(new AnalysisSummary() {
+            @Override
+            public Long getId() {
+                return null;
+            }
+
+            @Override
+            public String getReportName() {
+                return null;
+            }
+
+            @Override
+            public String getReportDescription() {
+                return null;
+            }
+
+            @Override
+            public String getPayloadName() {
+                return null;
+            }
+
+            @Override
+            public Date getInserted() {
+                return null;
+            }
+
+            @Override
+            public Date getLastUpdate() {
+                return null;
+            }
+
+            @Override
+            public String getStatus() {
+                return null;
+            }
+        });
         doNothing().when(analysisService).deleteById(one);
 
         //When
@@ -485,7 +522,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         //Then
         Assert.assertEquals(response.getStatusCodeValue(), HttpServletResponse.SC_NO_CONTENT);
         Assert.assertNull(response.getBody());
-        verify(analysisService).findByOwnerAndId("mrizzi@redhat.com",one);
+        verify(analysisService).findAnalysisSummaryByOwnerAndId("mrizzi@redhat.com",one);
         verify(analysisService).deleteById(one);
         assertThat(response).isNotNull();
         assertThat(response.getBody()).isNull();
@@ -524,7 +561,42 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
     public void xmlRouteBuilder_RestReportIdWorkloadInventory_IdParamGiven_ShouldCallFindByAnalysisIdAndReturnAvailableFilters() throws Exception {
         //Given
         Long one = 1L;
-        when(analysisService.findByOwnerAndId("mrizzi@redhat.com", one)).thenReturn(new AnalysisModel());
+        when(analysisService.findAnalysisSummaryByOwnerAndId("mrizzi@redhat.com", one)).thenReturn(new AnalysisSummary() {
+            @Override
+            public Long getId() {
+                return null;
+            }
+
+            @Override
+            public String getReportName() {
+                return null;
+            }
+
+            @Override
+            public String getReportDescription() {
+                return null;
+            }
+
+            @Override
+            public String getPayloadName() {
+                return null;
+            }
+
+            @Override
+            public Date getInserted() {
+                return null;
+            }
+
+            @Override
+            public Date getLastUpdate() {
+                return null;
+            }
+
+            @Override
+            public String getStatus() {
+                return null;
+            }
+        });
 
         //When
         camelContext.start();
@@ -539,7 +611,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         ResponseEntity<String> response = restTemplate.exchange(camel_context + "report/{id}/workload-inventory/available-filters" , HttpMethod.GET, entity, String.class, variables);
 
         //Then
-        verify(analysisService).findByOwnerAndId("mrizzi@redhat.com", one);
+        verify(analysisService).findAnalysisSummaryByOwnerAndId("mrizzi@redhat.com", one);
         verify(workloadInventoryReportService).findAvailableFiltersByAnalysisId(one);
         assertThat(response).isNotNull();
         camelContext.stop();
@@ -819,7 +891,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         ResponseEntity<String> answer = restTemplate.exchange(camel_context + "report/15/payload", HttpMethod.GET, entity, String.class);
 
         //Then
-        assertThat(answer.getBody()).isEqualToIgnoringCase(IOUtils.resourceToString("cloudforms-export-v1_0_0.json", StandardCharsets.UTF_8, this.getClass().getClassLoader()));
+        assertThat(answer.getBody()).isEqualToIgnoringCase(IOUtils.toString(getClass().getClassLoader().getResource("cloudforms-export-v1_0_0.json"), StandardCharsets.UTF_8));
         assertThat(answer.getHeaders().get("Content-Disposition").get(0)).isEqualToIgnoringCase("attachment; filename=\"cloudforms-export-v1_0_0.json\"");
 
         camelContext.stop();

--- a/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
@@ -169,7 +169,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         ResponseEntity<String> response = restTemplate.exchange(camel_context + "report?page={page}&size={size}&filterText={filterText}", HttpMethod.GET, entity, String.class, variables);
 
         //Then
-        verify(analysisService).findByOwnerAndReportName("mrizzi@redhat.com", filterText, page, size);
+        verify(analysisService).findAnalysisSummaryByOwnerAndReportName("mrizzi@redhat.com", filterText, page, size);
         assertThat(response).isNotNull();
         assertThat(response.getBody()).contains("\"content\":[]");
         assertThat(response.getBody()).contains("\"size\":3");

--- a/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
@@ -920,7 +920,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         ResponseEntity<String> answer = restTemplate.exchange(camel_context + "report/15/payload", HttpMethod.GET, entity, String.class);
 
         //Then
-        assertThat(answer.getBody()).isEqualToIgnoringCase(IOUtils.toString(getClass().getClassLoader().getResource("cloudforms-export-v1_0_0.json"), StandardCharsets.UTF_8));
+        assertThat(answer.getBody()).isEqualToIgnoringCase(IOUtils.resourceToString("cloudforms-export-v1_0_0.json", StandardCharsets.UTF_8, this.getClass().getClassLoader()));
         assertThat(answer.getHeaders().get("Content-Disposition").get(0)).isEqualToIgnoringCase("attachment; filename=\"cloudforms-export-v1_0_0.json\"");
 
         camelContext.stop();


### PR DESCRIPTION
- Added projection to avoid loading the "eager" data in the polling call done from the analysis list page. It's a workaround (or maybe a solution?) waiting from the lazy option to work.
- Fixed `filterText` to avoid running "like" queries when no value provided