### PR TITLE
MIGENG-433 Fixed RecommendedTargetsIMSModel.calculateRecommendedTargetsIMS query

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.12.2</version>
+            <version>3.15.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/summary/RecommendedTargetsIMSModel.java
+++ b/src/main/java/org/jboss/xavier/analytics/pojo/output/workload/summary/RecommendedTargetsIMSModel.java
@@ -21,7 +21,7 @@ import javax.persistence.*;
 
 @NamedNativeQuery(
         name = "RecommendedTargetsIMSModel.calculateRecommendedTargetsIMS",
-        query = "select count(distinct wi.id) as total, coalesce(sum(case when lower(rt.recommended_targetsims)='rhv' then 1 else 0 end), 0) as rhv, coalesce(sum(case when lower(rt.recommended_targetsims)='osp' then 1 else 0 end), 0) as osp, coalesce(sum(case when lower(rt.recommended_targetsims)='convert2rhel' then 1 else 0 end), 0) as rhel from workload_inventory_report_model_recommended_targetsims rt right join workload_inventory_report_model wi on rt.workload_inventory_report_model_id=wi.id where wi.analysis_id = :analysisId",
+        query = "select count(distinct wi.id) as total, coalesce(sum(case when lower(rt.recommended_targetsims)='rhv' then 1 else 0 end), 0) as rhv, coalesce(sum(case when lower(rt.recommended_targetsims)='osp' then 1 else 0 end), 0) as osp, coalesce(sum(case when lower(rt.recommended_targetsims)='rhel' then 1 else 0 end), 0) as rhel from workload_inventory_report_model_recommended_targetsims rt right join workload_inventory_report_model wi on rt.workload_inventory_report_model_id=wi.id where wi.analysis_id = :analysisId",
         resultSetMapping = "mappingRecommendedTargetsIMSModels"
 )
 

--- a/src/test/java/org/jboss/xavier/integrations/EndToEndTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/EndToEndTest.java
@@ -430,10 +430,17 @@ public class EndToEndTest {
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().filter(e -> e.getComplexity().contains("Unsupported")).count()).isEqualTo(1);
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().flatMap(e -> e.getRecommendedTargetsIMS().stream()).distinct().count()).isEqualTo(4);
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().filter(e -> e.getRecommendedTargetsIMS().contains("OSP")).count()).isEqualTo(11);
+            softly.assertThat(workloadInventoryReport.getBody().getContent().stream().filter(e -> e.getRecommendedTargetsIMS().contains("RHEL")).count()).isEqualTo(4);
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().flatMap(e -> e.getFlagsIMS().stream()).distinct().count()).isEqualTo(2);
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().filter(e -> e.getFlagsIMS().contains("Shared Disk")).count()).isEqualTo(2);
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().filter(e -> e.getOsName().contains("ServerNT") && e.getWorkloads().contains("Microsoft SQL Server")).count()).isEqualTo(1);
         });
+
+        WorkloadInventoryReportModel[] workloadInventoryReportModelExpected = new ObjectMapper().readValue(IOUtils.resourceToString("cfme_inventory-20190912-demolab-withssa-workload-inventory-report.json", StandardCharsets.UTF_8, EndToEndTest.class.getClassLoader()), WorkloadInventoryReportModel[].class);
+        assertThat(workloadInventoryReport.getBody().getContent().toArray())
+                .usingRecursiveComparison()
+                .ignoringFieldsMatchingRegexes(".*id.*", ".*creationDate.*")
+                .isEqualTo(workloadInventoryReportModelExpected);
 
         // Checks on Workload Summary Report
         WorkloadSummaryReportModel workloadSummaryReport_Expected = new ObjectMapper().readValue(IOUtils.resourceToString("cfme_inventory-20190912-demolab-withssa-workload-summary-report.json", StandardCharsets.UTF_8, EndToEndTest.class.getClassLoader()), WorkloadSummaryReportModel.class);

--- a/src/test/java/org/jboss/xavier/integrations/EndToEndTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/EndToEndTest.java
@@ -431,6 +431,7 @@ public class EndToEndTest {
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().flatMap(e -> e.getRecommendedTargetsIMS().stream()).distinct().count()).isEqualTo(4);
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().filter(e -> e.getRecommendedTargetsIMS().contains("OSP")).count()).isEqualTo(11);
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().filter(e -> e.getRecommendedTargetsIMS().contains("RHEL")).count()).isEqualTo(4);
+            softly.assertThat(workloadInventoryReport.getBody().getContent().stream().filter(e -> e.getRecommendedTargetsIMS().contains("None")).count()).isEqualTo(1);
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().flatMap(e -> e.getFlagsIMS().stream()).distinct().count()).isEqualTo(2);
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().filter(e -> e.getFlagsIMS().contains("Shared Disk")).count()).isEqualTo(2);
             softly.assertThat(workloadInventoryReport.getBody().getContent().stream().filter(e -> e.getOsName().contains("ServerNT") && e.getWorkloads().contains("Microsoft SQL Server")).count()).isEqualTo(1);

--- a/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModelTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModelTest.java
@@ -62,10 +62,10 @@ public class WorkloadSummaryReportRoutes_DirectCalculateVMWorkloadInventoryModel
         String[] complexities = new String[]{"Easy", "Easy", "Medium", "Hard", "Unknown", null};
 
         List<Set<String>> recommendedTargetsIMS = new ArrayList<>(Arrays.asList(
-                new HashSet<>(Arrays.asList("rhv", "osp", "convert2rhel")),
+                new HashSet<>(Arrays.asList("rhv", "osp", "RHEL")),
                 new HashSet<>(Arrays.asList("rhv", "osp")),
-                new HashSet<>(Arrays.asList("osp", "convert2rhel")),
-                new HashSet<>(Collections.singletonList("convert2rhel")),
+                new HashSet<>(Arrays.asList("osp", "rhel")),
+                new HashSet<>(Collections.singletonList("RHEL")),
                 new HashSet<>(Collections.singletonList("other")),
                 new HashSet<>()
         ));

--- a/src/test/resources/cfme_inventory-20190912-demolab-withssa-workload-inventory-report.json
+++ b/src/test/resources/cfme_inventory-20190912-demolab-withssa-workload-inventory-report.json
@@ -1,7 +1,6 @@
-{
-    "content": [
+[
       {
-        "id": 24768,
+        "id": 48036,
         "provider": "vSphere",
         "datacenter": "Datacenter",
         "cluster": "VMCluster",
@@ -25,7 +24,7 @@
         "ssaEnabled": true
       },
       {
-        "id": 24767,
+        "id": 48035,
         "provider": "vSphere",
         "datacenter": "Datacenter",
         "cluster": "VMCluster",
@@ -52,7 +51,7 @@
         "ssaEnabled": true
       },
       {
-        "id": 24766,
+        "id": 48034,
         "provider": "vSphere",
         "datacenter": "Datacenter",
         "cluster": "VMCluster",
@@ -66,7 +65,7 @@
         "complexity": "Medium",
         "recommendedTargetsIMS": [
           "RHV",
-          "Convert2RHEL",
+          "RHEL",
           "OSP"
         ],
         "flagsIMS": [
@@ -79,7 +78,7 @@
         "ssaEnabled": false
       },
       {
-        "id": 24765,
+        "id": 48033,
         "provider": "vSphere",
         "datacenter": "Datacenter",
         "cluster": "VMCluster",
@@ -93,7 +92,7 @@
         "complexity": "Medium",
         "recommendedTargetsIMS": [
           "RHV",
-          "Convert2RHEL",
+          "RHEL",
           "OSP"
         ],
         "flagsIMS": [
@@ -106,7 +105,7 @@
         "ssaEnabled": false
       },
       {
-        "id": 24764,
+        "id": 48032,
         "provider": "vSphere",
         "datacenter": "Datacenter",
         "cluster": "VMCluster",
@@ -132,7 +131,7 @@
         "ssaEnabled": true
       },
       {
-        "id": 24763,
+        "id": 48031,
         "provider": "vSphere",
         "datacenter": "Datacenter",
         "cluster": "VMCluster",
@@ -148,7 +147,7 @@
         "complexity": "Medium",
         "recommendedTargetsIMS": [
           "RHV",
-          "Convert2RHEL",
+          "RHEL",
           "OSP"
         ],
         "flagsIMS": [],
@@ -159,7 +158,7 @@
         "ssaEnabled": true
       },
       {
-        "id": 24762,
+        "id": 48030,
         "provider": "vSphere",
         "datacenter": "Datacenter",
         "cluster": "VMCluster",
@@ -185,7 +184,7 @@
         "ssaEnabled": true
       },
       {
-        "id": 24761,
+        "id": 48029,
         "provider": "vSphere",
         "datacenter": "Datacenter",
         "cluster": "VMCluster",
@@ -209,7 +208,7 @@
         "ssaEnabled": true
       },
       {
-        "id": 24760,
+        "id": 48028,
         "provider": "vSphere",
         "datacenter": "Datacenter",
         "cluster": "VMCluster",
@@ -236,7 +235,7 @@
         "ssaEnabled": true
       },
       {
-        "id": 24759,
+        "id": 48027,
         "provider": "vSphere",
         "datacenter": "Datacenter",
         "cluster": "VMCluster",
@@ -260,23 +259,107 @@
         "host_name": "host-31",
         "creationDate": 1568305947979,
         "ssaEnabled": true
-      }
-    ],
-    "last": false,
-    "totalPages": 2,
-    "totalElements": 14,
-    "first": true,
-    "sort": [
+      },
       {
-        "direction": "DESC",
-        "property": "id",
-        "ignoreCase": false,
-        "nullHandling": "NATIVE",
-        "ascending": false,
-        "descending": true
+        "id": 48026,
+        "provider": "vSphere",
+        "datacenter": "Datacenter",
+        "cluster": "VMCluster",
+        "vmName": "tomcat",
+        "osName": "Linux",
+        "osDescription": "CentOS Linux release 7.6.1810 (Core) ",
+        "diskSpace": 2159235072,
+        "memory": 2147483648,
+        "cpuCores": 1,
+        "workloads": [
+          "Tomcat"
+        ],
+        "complexity": "Medium",
+        "recommendedTargetsIMS": [
+          "RHV",
+          "RHEL",
+          "OSP"
+        ],
+        "flagsIMS": [],
+        "product": "VMware vCenter",
+        "version": "6.7.2",
+        "host_name": "host-47",
+        "creationDate": 1568305947979,
+        "ssaEnabled": true
+      },
+      {
+        "id": 48025,
+        "provider": "vSphere",
+        "datacenter": "Datacenter",
+        "cluster": "VMCluster",
+        "vmName": "hana",
+        "osName": "Linux",
+        "osDescription": "Red Hat Enterprise Linux Server release 7.6 (Maipo)",
+        "diskSpace": 17860726784,
+        "memory": 17179869184,
+        "cpuCores": 4,
+        "workloads": [
+          "SAP HANA"
+        ],
+        "complexity": "Easy",
+        "recommendedTargetsIMS": [
+          "RHV",
+          "OSP"
+        ],
+        "flagsIMS": [],
+        "product": "VMware vCenter",
+        "version": "6.7.2",
+        "host_name": "host-47",
+        "creationDate": 1568305947979,
+        "ssaEnabled": true
+      },
+      {
+        "id": 48024,
+        "provider": "vSphere",
+        "datacenter": "Datacenter",
+        "cluster": "VMCluster",
+        "vmName": "websphere",
+        "osName": "Linux",
+        "osDescription": "Red Hat Enterprise Linux Server release 7.7 (Maipo)",
+        "diskSpace": 9332674560,
+        "memory": 2147483648,
+        "cpuCores": 1,
+        "workloads": [
+          "IBM Websphere App Server"
+        ],
+        "complexity": "Easy",
+        "recommendedTargetsIMS": [
+          "RHV",
+          "OSP"
+        ],
+        "flagsIMS": [],
+        "product": "VMware vCenter",
+        "version": "6.7.2",
+        "host_name": "host-47",
+        "creationDate": 1568305947979,
+        "ssaEnabled": true
+      },
+      {
+        "id": 48023,
+        "provider": "vSphere",
+        "datacenter": "Datacenter",
+        "cluster": "VMCluster",
+        "vmName": "freebsd",
+        "osName": "FreeBSD 12 or later versions (64-bit)",
+        "osDescription": "FreeBSD 12 or later versions (64-bit)",
+        "diskSpace": 0,
+        "memory": 1073741824,
+        "cpuCores": 1,
+        "workloads": [],
+        "complexity": "Unsupported",
+        "recommendedTargetsIMS": [
+          "None"
+        ],
+        "flagsIMS": [],
+        "product": "VMware vCenter",
+        "version": "6.7.2",
+        "host_name": "host-31",
+        "creationDate": 1568305947979,
+        "ssaEnabled": false
       }
-    ],
-    "numberOfElements": 10,
-    "size": 10,
-    "number": 0
-  }
+]

--- a/src/test/resources/cfme_inventory-20190912-demolab-withssa-workload-summary-report.json
+++ b/src/test/resources/cfme_inventory-20190912-demolab-withssa-workload-summary-report.json
@@ -24,7 +24,7 @@
       "id": 410,
       "total": 14,
       "rhv": 13,
-      "rhel": 0,
+      "rhel": 4,
       "osp": 11
     },
     "workloadsDetectedOSTypeModels": [


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-433

- `convert2rhel` changed to `rhel` according to https://github.com/project-xavier/xavier-analytics/pull/40/files#diff-549511b11dc443fded69b06b7544a68aR60
- added full (14VMs) WIR test against updated `cfme_inventory-20190912-demolab-withssa-workload-inventory-report.json`
- updated `assertj-core` to have `usingRecursiveComparison()` method (ref https://github.com/joel-costigliola/assertj-core/commit/11cb2727fb4afc0df9fe11996dde7cecc028bd2e)