### PR TITLE
MIGENG-327 hotfix cpucores 0 vm not removed

### DIFF
--- a/src/main/java/org/jboss/xavier/integrations/migrationanalytics/business/ParamsCalculator.java
+++ b/src/main/java/org/jboss/xavier/integrations/migrationanalytics/business/ParamsCalculator.java
@@ -29,8 +29,8 @@ public class ParamsCalculator implements Calculator<UploadFormInputDataModel> {
     public Integer calculateHypervisors(Map valuesMap, String cpuTotalCoresPath, String cpuCoresPerSocketPath, String analysisId) {
         Integer cputotalcores = getMapValueAvoidClassCastException(valuesMap, cpuTotalCoresPath, Integer.class);
         Integer cpucorespersocket = getMapValueAvoidClassCastException(valuesMap, cpuCoresPerSocketPath, Integer.class);
-        if (cputotalcores != null && cpucorespersocket != null && cpucorespersocket > 0) {
-            return (int) Math.ceil(cputotalcores / (cpucorespersocket * 2.0));
+        if (cputotalcores != null && cpucorespersocket != null ) {
+            return (int) ((cpucorespersocket > 0) ? Math.ceil(cputotalcores / (cpucorespersocket * 2.0)) : 0);
         } else {
             analysisIssuesHandler.record(analysisId, "HOST", valuesMap.get("name").toString(), cpuCoresPerSocketPath, "Invalid values to calculate Hypervisors number");
             return null;

--- a/src/main/java/org/jboss/xavier/integrations/migrationanalytics/business/VMWorkloadInventoryCalculator.java
+++ b/src/main/java/org/jboss/xavier/integrations/migrationanalytics/business/VMWorkloadInventoryCalculator.java
@@ -72,8 +72,8 @@ public class VMWorkloadInventoryCalculator extends AbstractVMWorkloadInventoryCa
 
         Integer numCPU = readValueFromExpandedEnvVarPath(NUMCPUPATH, vmStructMap, Integer.class);
         Integer numCORES = readValueFromExpandedEnvVarPath(NUMCORESPERSOCKETPATH, vmStructMap, Integer.class);
-        if (numCPU != null && numCORES != null && numCORES > 0) {
-            model.setCpuCores((numCPU / numCORES));
+        if (numCPU != null && numCORES != null) {
+            model.setCpuCores(numCORES > 0 ? (numCPU / numCORES) : 0);
         } else {
             analysisIssuesHandler.record(vmStructMap.get("_analysisId").toString(), "VM", vmStructMap.get("name").toString(), getExpandedPath(NUMCORESPERSOCKETPATH, vmStructMap), "CpuCores could not be calculated.");
         }

--- a/src/test/java/org/jboss/xavier/integrations/EndToEndTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/EndToEndTest.java
@@ -72,6 +72,7 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
@@ -468,13 +469,13 @@ public class EndToEndTest {
         logger.info("+++++++  Performance Test ++++++");
 
         new RestTemplate().postForEntity("http://localhost:" + serverPort + "/api/xavier/upload", getRequestEntityForUploadRESTCall("cfme_inventory-20190829-16128-uq17dx.tar.gz", "application/zip"), String.class);
-        callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_PerformaceTest, 142);
+        assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_PerformaceTest)).isEqualTo(142);
 
         // Test with a file with VM without Host
         logger.info("+++++++  Test with a file with VM without Host ++++++");
 
         new RestTemplate().postForEntity("http://localhost:" + serverPort + "/api/xavier/upload", getRequestEntityForUploadRESTCall("cloudforms-export-v1_0_0-vm_without_host.json", "application/json"), String.class);
-        callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_InitialCostSavingsReport, 8);
+        assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_InitialCostSavingsReport)).isEqualTo(8);
 
         ResponseEntity<PagedResources<WorkloadInventoryReportModel>> workloadInventoryReport_file_vm_without_host = new RestTemplate().exchange("http://localhost:" + serverPort + String.format("/api/xavier/report/%d/workload-inventory?size=100", analysisNum), HttpMethod.GET, getRequestEntity(), new ParameterizedTypeReference<PagedResources<WorkloadInventoryReportModel>>() {});
         assertThat(workloadInventoryReport_file_vm_without_host.getBody().getContent().size()).isEqualTo(8);
@@ -484,7 +485,7 @@ public class EndToEndTest {
         // Test with a file with Host without Cluster
         logger.info("+++++++  Test with a file with Host without Cluster ++++++");
         new RestTemplate().postForEntity("http://localhost:" + serverPort + "/api/xavier/upload", getRequestEntityForUploadRESTCall("cloudforms-export-v1_0_0-host_without_cluster.json", "application/json"), String.class);
-        callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_InitialCostSavingsReport, 8);
+        assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_InitialCostSavingsReport)).isEqualTo(8);
 
         ResponseEntity<PagedResources<WorkloadInventoryReportModel>> workloadInventoryReport_file_host_without_cluster = new RestTemplate().exchange("http://localhost:" + serverPort + String.format("/api/xavier/report/%d/workload-inventory?size=100", analysisNum), HttpMethod.GET, getRequestEntity(), new ParameterizedTypeReference<PagedResources<WorkloadInventoryReportModel>>() {});
         // Total VMs
@@ -497,7 +498,7 @@ public class EndToEndTest {
         // Test with a file with Wrong CPU cores per socket
         logger.info("+++++++  Test with a file with Wrong CPU cores per socket ++++++");
         new RestTemplate().postForEntity("http://localhost:" + serverPort + "/api/xavier/upload", getRequestEntityForUploadRESTCall("cloudforms-export-v1_0_0-wrong_cpu_cores_per_socket.json", "application/json"), String.class);
-        callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_InitialCostSavingsReport, 5);
+        assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_InitialCostSavingsReport)).isEqualTo(5);
 
         ResponseEntity<InitialSavingsEstimationReportModel> initialCostSavingsReport_wrong_cpu_cores = new RestTemplate().exchange("http://localhost:" + serverPort + String.format("/api/xavier/report/%d/initial-saving-estimation", analysisNum), HttpMethod.GET, getRequestEntity(), new ParameterizedTypeReference<InitialSavingsEstimationReportModel>() {});
         assertThat(initialCostSavingsReport_wrong_cpu_cores.getBody().getEnvironmentModel().getHypervisors()).isEqualTo(2);
@@ -507,11 +508,24 @@ public class EndToEndTest {
         assertThat(workloadInventoryReport_file_wrong_cpu_cores.getBody().getContent().stream().filter(e -> e.getCpuCores() != null).count()).isEqualTo(5);
         assertThat(workloadInventoryReport_file_wrong_cpu_cores.getBody().getContent().size()).isEqualTo(5);
 
+        // Test with a file with 0 CPU cores per socket
+        logger.info("+++++++  Test with a file with 0 CPU cores per socket ++++++");
+        new RestTemplate().postForEntity("http://localhost:" + serverPort + "/api/xavier/upload", getRequestEntityForUploadRESTCall("cloudforms-export-v1_0_0-vm_with_0_cores.json", "application/json"), String.class);
+        assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_InitialCostSavingsReport)).isEqualTo(8);
+
+        ResponseEntity<InitialSavingsEstimationReportModel> initialCostSavingsReport_zero_cpu_cores = new RestTemplate().exchange("http://localhost:" + serverPort + String.format("/api/xavier/report/%d/initial-saving-estimation", analysisNum), HttpMethod.GET, getRequestEntity(), new ParameterizedTypeReference<InitialSavingsEstimationReportModel>() {});
+        assertThat(initialCostSavingsReport_zero_cpu_cores.getBody().getEnvironmentModel().getHypervisors()).isEqualTo(2);
+
+        ResponseEntity<PagedResources<WorkloadInventoryReportModel>> workloadInventoryReport_file_zero_cpu_cores = new RestTemplate().exchange("http://localhost:" + serverPort + String.format("/api/xavier/report/%d/workload-inventory?size=100", analysisNum), HttpMethod.GET, getRequestEntity(), new ParameterizedTypeReference<PagedResources<WorkloadInventoryReportModel>>() {});
+        assertThat(workloadInventoryReport_file_zero_cpu_cores.getBody().getContent().stream().filter(e -> e.getCpuCores() == null).count()).isEqualTo(0);
+        assertThat(workloadInventoryReport_file_zero_cpu_cores.getBody().getContent().stream().filter(e -> e.getCpuCores() != null).count()).isEqualTo(8);
+        assertThat(workloadInventoryReport_file_zero_cpu_cores.getBody().getContent().size()).isEqualTo(8);
+
 
         // Ultra Performance test
         logger.info("+++++++  Ultra Performance Test ++++++");
         new RestTemplate().postForEntity("http://localhost:" + serverPort + "/api/xavier/upload", getRequestEntityForUploadRESTCall("cfme_inventory20190807-32152-jimd0q_large_dataset_5254_vms.tar.gz", "application/zip"), String.class);
-        callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_UltraPerformaceTest, numberVMsExpected_InBigFile);
+        assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", ++analysisNum), timeoutMilliseconds_UltraPerformaceTest)).isEqualTo(numberVMsExpected_InBigFile);
 
         // Stress test
         // We load 3 times a BIG file ( 8 Mb ) and 2 times a small file ( 316 Kb )
@@ -527,17 +541,18 @@ public class EndToEndTest {
         new RestTemplate().postForEntity("http://localhost:" + serverPort + "/api/xavier/upload", getRequestEntityForUploadRESTCall("cloudforms-export-v1_0_0.json", "application/json"), String.class);
 
         // We will check for time we retrieve the third file uploaded to see previous ones are not affecting
-        callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", analysisNum + 2), timeoutMilliseconds_SmallFileSummaryReport, 8);
-        callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", analysisNum + 1), timeoutMilliseconds_UltraPerformaceTest, numberVMsExpected_InBigFile);
-        callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", analysisNum + 3), timeoutMilliseconds_UltraPerformaceTest, numberVMsExpected_InBigFile);
+        assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", analysisNum + 2), timeoutMilliseconds_SmallFileSummaryReport)).isEqualTo(8);
+        assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", analysisNum + 1), timeoutMilliseconds_UltraPerformaceTest)).isEqualTo(numberVMsExpected_InBigFile);
+        assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", analysisNum + 3), timeoutMilliseconds_UltraPerformaceTest)).isEqualTo( numberVMsExpected_InBigFile);
 
         int timeoutMilliseconds_secondSmallFile = timeoutMilliseconds_UltraPerformaceTest + timeoutMilliseconds_SmallFileSummaryReport;
-        callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", analysisNum + 4), timeoutMilliseconds_secondSmallFile, 8);
+        assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", analysisNum + 4), timeoutMilliseconds_secondSmallFile)).isEqualTo( 8);
 
         camelContext.stop();
     }
 
-    private void callSummaryReportAndCheckVMs(final String reportUrl, int timeoutMilliseconds, int numberVMsExpected) {
+    private Integer callSummaryReportAndCheckVMs(final String reportUrl, int timeoutMilliseconds) {
+        List<Integer> numberVMsReceived = new ArrayList<>();
         await()
                 .atMost(timeoutMilliseconds, TimeUnit.MILLISECONDS)
                 .with().pollInterval(Duration.ONE_SECOND)
@@ -549,18 +564,11 @@ public class EndToEndTest {
                             workloadSummaryReport_stress_checkVMs.getBody() != null &&
                             workloadSummaryReport_stress_checkVMs.getBody().getSummaryModels() != null );
                     if (success) {
-                       assertThat(workloadSummaryReport_stress_checkVMs.getBody().getSummaryModels().stream().mapToInt(SummaryModel::getVms).sum()).isEqualTo(numberVMsExpected);
+                       numberVMsReceived.add(workloadSummaryReport_stress_checkVMs.getBody().getSummaryModels().stream().mapToInt(SummaryModel::getVms).sum());
                     }
                     return success;
                 });
-    }
-
-    private int getWorkloadSummaryReportModelResponseVMs(int analysisNum) {
-        final String workloadsummaryreport_stress_url = String.format("/api/xavier/report/%d/workload-summary", analysisNum );
-        ResponseEntity<WorkloadSummaryReportModel> response = new RestTemplate().exchange("http://localhost:" + serverPort + workloadsummaryreport_stress_url, HttpMethod.GET, getRequestEntity(), new ParameterizedTypeReference<WorkloadSummaryReportModel>() {
-        });
-        logger.info("URL [{}] response [{}]", workloadsummaryreport_stress_url, response.getBody());
-        return response.getBody().getSummaryModels().stream().mapToInt(SummaryModel::getVms).sum();
+        return numberVMsReceived.get(0);
     }
 
     @NotNull

--- a/src/test/java/org/jboss/xavier/integrations/EndToEndTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/EndToEndTest.java
@@ -72,7 +72,6 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Enumeration;
 import java.util.List;
@@ -80,6 +79,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -552,7 +552,7 @@ public class EndToEndTest {
     }
 
     private Integer callSummaryReportAndCheckVMs(final String reportUrl, int timeoutMilliseconds) {
-        List<Integer> numberVMsReceived = new ArrayList<>();
+        AtomicInteger numberVMsReceived = new AtomicInteger(0);
         await()
                 .atMost(timeoutMilliseconds, TimeUnit.MILLISECONDS)
                 .with().pollInterval(Duration.ONE_SECOND)
@@ -564,11 +564,11 @@ public class EndToEndTest {
                             workloadSummaryReport_stress_checkVMs.getBody() != null &&
                             workloadSummaryReport_stress_checkVMs.getBody().getSummaryModels() != null );
                     if (success) {
-                       numberVMsReceived.add(workloadSummaryReport_stress_checkVMs.getBody().getSummaryModels().stream().mapToInt(SummaryModel::getVms).sum());
+                       numberVMsReceived.set(workloadSummaryReport_stress_checkVMs.getBody().getSummaryModels().stream().mapToInt(SummaryModel::getVms).sum());
                     }
                     return success;
                 });
-        return numberVMsReceived.get(0);
+        return numberVMsReceived.intValue();
     }
 
     @NotNull

--- a/src/test/java/org/jboss/xavier/integrations/migrationanalytics/business/ParamsCalculatorTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/migrationanalytics/business/ParamsCalculatorTest.java
@@ -151,7 +151,7 @@ public class ParamsCalculatorTest {
         mapa.put("cpu_total_cores", 4);
         mapa.put("cpu_cores_per_socket", 0);
         mapa.put("ems_cluster_id", 1);
-        assertThat(reportCalculator.calculateHypervisors(mapa, "cpu_total_cores", "cpu_cores_per_socket", analysisId.toString())).isNull();
+        assertThat(reportCalculator.calculateHypervisors(mapa, "cpu_total_cores", "cpu_cores_per_socket", analysisId.toString())).isEqualTo(0);
     }
 
     @Test

--- a/src/test/java/org/jboss/xavier/integrations/migrationanalytics/business/VMWorkloadInventoryCalculatorTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/migrationanalytics/business/VMWorkloadInventoryCalculatorTest.java
@@ -184,9 +184,10 @@ public class VMWorkloadInventoryCalculatorTest {
     }
 
     @Test
-    public void calculate_jsonV1_0_0_GivenWithCoresEquals0_ShouldReturn0CpuCores() throws IOException, ParseException {
+    public void calculate_jsonV1_0_0_GivenWithCoresEquals0_ShouldReturn0CpuCores() throws IOException {
         String cloudFormsJson = IOUtils.resourceToString("cloudforms-export-v1_0_0.json", StandardCharsets.UTF_8, VMWorkloadInventoryCalculatorTest.class.getClassLoader());
-        cloudFormsJson = cloudFormsJson.replace("\"cpu_total_cores\": 4,", "\"cpu_total_cores\": 0,");
+        cloudFormsJson = cloudFormsJson.replace("\"cpu_cores_per_socket\": 1,\n                    \"cpu_total_cores\": 4,",
+                                           "\"cpu_cores_per_socket\": 0,\n                    \"cpu_total_cores\": 4,");
 
         Map<String, Object> headers = new HashMap<>();
         Long analysisId = 30L;

--- a/src/test/java/org/jboss/xavier/integrations/migrationanalytics/business/VMWorkloadInventoryCalculatorTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/migrationanalytics/business/VMWorkloadInventoryCalculatorTest.java
@@ -182,4 +182,21 @@ public class VMWorkloadInventoryCalculatorTest {
         assertThat(modelList.stream().filter(e -> e.getVmName().equalsIgnoreCase("oracle_db"))
                 .findFirst().get().getCluster()).isNull();
     }
+
+    @Test
+    public void calculate_jsonV1_0_0_GivenWithCoresEquals0_ShouldReturn0CpuCores() throws IOException, ParseException {
+        String cloudFormsJson = IOUtils.resourceToString("cloudforms-export-v1_0_0.json", StandardCharsets.UTF_8, VMWorkloadInventoryCalculatorTest.class.getClassLoader());
+        cloudFormsJson = cloudFormsJson.replace("\"cpu_total_cores\": 4,", "\"cpu_total_cores\": 0,");
+
+        Map<String, Object> headers = new HashMap<>();
+        Long analysisId = 30L;
+        headers.put(RouteBuilderExceptionHandler.ANALYSIS_ID, analysisId.toString());
+
+        Collection<VMWorkloadInventoryModel> modelList = calculator.calculate(cloudFormsJson, headers);
+        assertThat(Integer.valueOf(modelList.size())).isEqualTo(8);
+
+        assertThat(modelList.stream().filter(e -> e.getVmName().equalsIgnoreCase("hana"))
+                .findFirst().get().getCpuCores())
+                .isEqualTo(0);
+    }
 }

--- a/src/test/resources/cloudforms-export-v1_0_0-vm_with_0_cores.json
+++ b/src/test/resources/cloudforms-export-v1_0_0-vm_with_0_cores.json
@@ -1,0 +1,7731 @@
+{
+    "cfme_version": "5.11.0.17",
+    "data_collected_on": "2019-09-18T14:52:45.871Z",
+    "schema": {
+        "name": "Cfme"
+    },
+    "manifest": {
+        "cfme_version": "5.11",
+        "manifest": {
+            "version": "1.0.0",
+            "core": {
+                "MiqDatabase": {
+                    "id": null,
+                    "guid": null,
+                    "region_number": null,
+                    "region_description": null
+                },
+                "Zone": {
+                    "id": null,
+                    "name": null
+                }
+            },
+            "ManageIQ::Providers::OpenStack::CloudManager": {
+                "id": null,
+                "name": null,
+                "type": null,
+                "guid": null,
+                "api_version": null,
+                "emstype_description": null,
+                "hostname": null,
+                "vms": {
+                    "id": null,
+                    "name": null,
+                    "description": null,
+                    "type": null,
+                    "uid_ems": null,
+                    "cpu_cores_per_socket": null,
+                    "cpu_total_cores": null,
+                    "disks_aligned": null,
+                    "ems_ref": null,
+                    "has_rdm_disk": null,
+                    "power_state": null,
+                    "ram_size_in_bytes": null,
+                    "retired": null,
+                    "v_datastore_path": null,
+                    "operating_system": {
+                        "product_type": null,
+                        "product_name": null,
+                        "distribution": null
+                    },
+                    "hardware": {
+                        "id": null,
+                        "guest_os_full_name": null,
+                        "disks": {
+                            "id": null,
+                            "device_name": null,
+                            "device_type": null,
+                            "disk_type": null,
+                            "filename": null,
+                            "free_space": null,
+                            "mode": null,
+                            "size": null,
+                            "size_on_disk": null
+                        },
+                        "nics": {
+                            "id": null,
+                            "device_name": null,
+                            "device_type": null,
+                            "address": null,
+                            "model": null,
+                            "uid_ems": null,
+                            "network": {
+                                "id": null,
+                                "ipaddress": null,
+                                "hostname": null
+                            }
+                        }
+                    },
+                    "files": {
+                        "id": null,
+                        "name": null,
+                        "contents": null
+                    },
+                    "system_services": {
+                        "id": null,
+                        "name": null,
+                        "typename": null
+                    }
+                }
+            },
+            "ManageIQ::Providers::Redhat::InfraManager": {
+                "id": null,
+                "name": null,
+                "type": null,
+                "guid": null,
+                "api_version": null,
+                "emstype_description": null,
+                "hostname": null,
+                "vms": {
+                    "id": null,
+                    "name": null,
+                    "description": null,
+                    "type": null,
+                    "uid_ems": null,
+                    "cpu_cores_per_socket": null,
+                    "cpu_total_cores": null,
+                    "disks_aligned": null,
+                    "ems_ref": null,
+                    "has_rdm_disk": null,
+                    "host": {
+                        "ems_ref": null
+                    },
+                    "power_state": null,
+                    "ram_size_in_bytes": null,
+                    "retired": null,
+                    "v_datastore_path": null,
+                    "operating_system": {
+                        "product_type": null,
+                        "product_name": null,
+                        "distribution": null
+                    },
+                    "hardware": {
+                        "id": null,
+                        "guest_os_full_name": null,
+                        "disks": {
+                            "id": null,
+                            "device_name": null,
+                            "device_type": null,
+                            "disk_type": null,
+                            "filename": null,
+                            "free_space": null,
+                            "mode": null,
+                            "size": null,
+                            "size_on_disk": null
+                        },
+                        "nics": {
+                            "id": null,
+                            "device_name": null,
+                            "device_type": null,
+                            "address": null,
+                            "model": null,
+                            "uid_ems": null,
+                            "network": {
+                                "id": null,
+                                "ipaddress": null,
+                                "hostname": null
+                            }
+                        }
+                    },
+                    "files": {
+                        "id": null,
+                        "name": null,
+                        "contents": null
+                    },
+                    "system_services": {
+                        "id": null,
+                        "name": null,
+                        "typename": null
+                    }
+                },
+                "ems_clusters": {
+                    "id": null,
+                    "name": null,
+                    "uid_ems": null,
+                    "ems_ref": null,
+                    "ha_enabled": null,
+                    "drs_enabled": null,
+                    "effective_cpu": null,
+                    "effective_memory": null
+                },
+                "hosts": {
+                    "id": null,
+                    "name": null,
+                    "type": null,
+                    "hostname": null,
+                    "ipaddress": null,
+                    "power_state": null,
+                    "guid": null,
+                    "uid_ems": null,
+                    "ems_ref": null,
+                    "mac_address": null,
+                    "maintenance": null,
+                    "vmm_vendor": null,
+                    "vmm_version": null,
+                    "vmm_product": null,
+                    "vmm_buildnumber": null,
+                    "archived": null,
+                    "cpu_cores_per_socket": null,
+                    "cpu_total_cores": null,
+                    "ems_cluster": {
+                        "ems_ref": null
+                    },
+                    "hardware": {
+                        "memory_mb": null
+                    }
+                },
+                "storages": {
+                    "id": null,
+                    "name": null,
+                    "location": null,
+                    "store_type": null,
+                    "total_space": null,
+                    "free_space": null,
+                    "uncommitted": null,
+                    "storage_domain_type": null,
+                    "host_storages": {
+                        "ems_ref": null,
+                        "host": {
+                            "ems_ref": null
+                        }
+                    }
+                }
+            },
+            "ManageIQ::Providers::Vmware::InfraManager": {
+                "id": null,
+                "name": null,
+                "type": null,
+                "guid": null,
+                "api_version": null,
+                "emstype_description": null,
+                "hostname": null,
+                "vms": {
+                    "id": null,
+                    "name": null,
+                    "description": null,
+                    "type": null,
+                    "uid_ems": null,
+                    "cpu_cores_per_socket": null,
+                    "cpu_total_cores": null,
+                    "disks_aligned": null,
+                    "ems_ref": null,
+                    "has_rdm_disk": null,
+                    "host": {
+                        "ems_ref": null
+                    },
+                    "power_state": null,
+                    "ram_size_in_bytes": null,
+                    "retired": null,
+                    "v_datastore_path": null,
+                    "operating_system": {
+                        "product_type": null,
+                        "product_name": null,
+                        "distribution": null
+                    },
+                    "hardware": {
+                        "id": null,
+                        "guest_os_full_name": null,
+                        "disks": {
+                            "id": null,
+                            "device_name": null,
+                            "device_type": null,
+                            "disk_type": null,
+                            "filename": null,
+                            "free_space": null,
+                            "mode": null,
+                            "size": null,
+                            "size_on_disk": null
+                        },
+                        "nics": {
+                            "id": null,
+                            "device_name": null,
+                            "device_type": null,
+                            "address": null,
+                            "model": null,
+                            "uid_ems": null,
+                            "network": {
+                                "id": null,
+                                "ipaddress": null,
+                                "hostname": null
+                            }
+                        }
+                    },
+                    "files": {
+                        "id": null,
+                        "name": null,
+                        "contents": null
+                    },
+                    "system_services": {
+                        "id": null,
+                        "name": null,
+                        "typename": null
+                    }
+                },
+                "ems_extensions": {
+                    "id": null,
+                    "ems_ref": null,
+                    "key": null,
+                    "company": null,
+                    "label": null,
+                    "summary": null,
+                    "version": null
+                },
+                "ems_licenses": {
+                    "id": null,
+                    "ems_ref": null,
+                    "name": null,
+                    "license_edition": null,
+                    "total_licenses": null,
+                    "used_licenses": null
+                },
+                "ems_clusters": {
+                    "id": null,
+                    "name": null,
+                    "uid_ems": null,
+                    "ems_ref": null,
+                    "ha_enabled": null,
+                    "drs_enabled": null,
+                    "effective_cpu": null,
+                    "effective_memory": null
+                },
+                "hosts": {
+                    "id": null,
+                    "name": null,
+                    "type": null,
+                    "hostname": null,
+                    "ipaddress": null,
+                    "power_state": null,
+                    "guid": null,
+                    "uid_ems": null,
+                    "ems_ref": null,
+                    "mac_address": null,
+                    "maintenance": null,
+                    "vmm_vendor": null,
+                    "vmm_version": null,
+                    "vmm_product": null,
+                    "vmm_buildnumber": null,
+                    "archived": null,
+                    "cpu_cores_per_socket": null,
+                    "cpu_total_cores": null,
+                    "ems_cluster": {
+                        "ems_ref": null
+                    },
+                    "hardware": {
+                        "memory_mb": null
+                    }
+                },
+                "storages": {
+                    "id": null,
+                    "name": null,
+                    "location": null,
+                    "store_type": null,
+                    "total_space": null,
+                    "free_space": null,
+                    "uncommitted": null,
+                    "storage_domain_type": null,
+                    "host_storages": {
+                        "ems_ref": null,
+                        "host": {
+                            "ems_ref": null
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "ManageIQ::Providers::Vmware::InfraManager": [
+        {
+            "id": 4,
+            "name": "vSphere",
+            "type": "ManageIQ::Providers::Vmware::InfraManager",
+            "guid": "8ada8916-3756-45f3-9d5f-2c655f2b2823",
+            "api_version": "6.7.2",
+            "emstype_description": "VMware vCenter",
+            "hostname": "vcenter.example.com",
+            "vms": [
+                {
+                    "id": 4,
+                    "name": "tomcat",
+                    "description": null,
+                    "type": "ManageIQ::Providers::Vmware::InfraManager::Vm",
+                    "uid_ems": "420a4754-572b-8b4b-897a-f174e45a2288",
+                    "cpu_cores_per_socket": 0,
+                    "cpu_total_cores": 0,
+                    "disks_aligned": "True",
+                    "ems_ref": "vm-321",
+                    "has_rdm_disk": false,
+                    "host": {
+                        "ems_ref": "host-31"
+                    },
+                    "power_state": "on",
+                    "ram_size_in_bytes": 2147483648,
+                    "retired": null,
+                    "v_datastore_path": "NFS-Storage/tomcat/tomcat.vmx",
+                    "operating_system": {
+                        "product_type": null,
+                        "product_name": null,
+                        "distribution": "CentOS"
+                    },
+                    "hardware": {
+                        "id": 8,
+                        "guest_os_full_name": "CentOS 7 (64-bit)",
+                        "disks": [
+                            {
+                                "id": 6,
+                                "device_name": "Hard disk 1",
+                                "device_type": "disk",
+                                "disk_type": "thin",
+                                "filename": "[NFS-Storage] tomcat/tomcat.vmdk",
+                                "free_space": null,
+                                "mode": "persistent",
+                                "size": 17179869184,
+                                "size_on_disk": 2159550464
+                            }
+                        ],
+                        "nics": [
+                            {
+                                "id": 16,
+                                "device_name": "Network adapter 1",
+                                "device_type": "ethernet",
+                                "address": "00:50:56:8a:8f:cc",
+                                "model": "VirtualVmxnet3",
+                                "uid_ems": "00:50:56:8a:8f:cc",
+                                "network": {
+                                    "id": 23,
+                                    "ipaddress": "10.10.0.180",
+                                    "hostname": "tomcat.example.com"
+                                }
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "id": 162,
+                            "name": "/etc/GeoIP.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 163,
+                            "name": "/etc/asound.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 164,
+                            "name": "/etc/chrony.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 165,
+                            "name": "/etc/dracut.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 166,
+                            "name": "/etc/e2fsck.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 167,
+                            "name": "/etc/fuse.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 168,
+                            "name": "/etc/host.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 169,
+                            "name": "/etc/kdump.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 170,
+                            "name": "/etc/krb5.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 171,
+                            "name": "/etc/ld.so.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 172,
+                            "name": "/etc/libaudit.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 173,
+                            "name": "/etc/libuser.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 174,
+                            "name": "/etc/locale.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 175,
+                            "name": "/etc/logrotate.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 176,
+                            "name": "/etc/man_db.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 177,
+                            "name": "/etc/mke2fs.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 178,
+                            "name": "/etc/nsswitch.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 179,
+                            "name": "/etc/resolv.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 180,
+                            "name": "/etc/rsyslog.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 181,
+                            "name": "/etc/sestatus.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 182,
+                            "name": "/etc/sudo-ldap.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 183,
+                            "name": "/etc/sudo.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 184,
+                            "name": "/etc/sysctl.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 185,
+                            "name": "/etc/vconsole.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 186,
+                            "name": "/etc/yum.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 187,
+                            "name": "/etc/group",
+                            "contents": "root:x:0:\nbin:x:1:\ndaemon:x:2:\nsys:x:3:\nadm:x:4:\ntty:x:5:\ndisk:x:6:\nlp:x:7:\nmem:x:8:\nkmem:x:9:\nwheel:x:10:\ncdrom:x:11:\nmail:x:12:postfix\nman:x:15:\ndialout:x:18:\nfloppy:x:19:\ngames:x:20:\ntape:x:33:\nvideo:x:39:\nftp:x:50:\nlock:x:54:\naudio:x:63:\nnobody:x:99:\nusers:x:100:\nutmp:x:22:\nutempter:x:35:\ninput:x:999:\nsystemd-journal:x:190:\nsystemd-network:x:192:\ndbus:x:81:\npolkitd:x:998:\nssh_keys:x:997:\nsshd:x:74:\npostdrop:x:90:\npostfix:x:89:\nchrony:x:996:\ntomcat:x:1000:\n"
+                        },
+                        {
+                            "id": 188,
+                            "name": "/etc/hosts",
+                            "contents": null
+                        }
+                    ],
+                    "system_services": [
+                        {
+                            "id": 823,
+                            "name": "tomcat",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 824,
+                            "name": "NetworkManager-dispatcher",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 825,
+                            "name": "NetworkManager-wait-online",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 826,
+                            "name": "NetworkManager",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 827,
+                            "name": "auditd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 828,
+                            "name": "blk-availability",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 829,
+                            "name": "brandbot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 830,
+                            "name": "chrony-dnssrv@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 831,
+                            "name": "chrony-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 832,
+                            "name": "chronyd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 833,
+                            "name": "console-getty",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 834,
+                            "name": "console-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 835,
+                            "name": "container-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 836,
+                            "name": "cpupower",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 837,
+                            "name": "crond",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 838,
+                            "name": "dbus",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 839,
+                            "name": "debug-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 840,
+                            "name": "dm-event",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 841,
+                            "name": "dracut-cmdline",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 842,
+                            "name": "dracut-initqueue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 843,
+                            "name": "dracut-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 844,
+                            "name": "dracut-pre-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 845,
+                            "name": "dracut-pre-pivot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 846,
+                            "name": "dracut-pre-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 847,
+                            "name": "dracut-pre-udev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 848,
+                            "name": "dracut-shutdown",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 849,
+                            "name": "ebtables",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 850,
+                            "name": "emergency",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 851,
+                            "name": "firewalld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 852,
+                            "name": "fstrim",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 853,
+                            "name": "getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 854,
+                            "name": "halt-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 855,
+                            "name": "initrd-cleanup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 856,
+                            "name": "initrd-parse-etc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 857,
+                            "name": "initrd-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 858,
+                            "name": "initrd-udevadm-cleanup-db",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 859,
+                            "name": "iprdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 860,
+                            "name": "iprinit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 861,
+                            "name": "iprupdate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 862,
+                            "name": "irqbalance",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 863,
+                            "name": "kdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 864,
+                            "name": "kmod-static-nodes",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 865,
+                            "name": "lvm2-lvmetad",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 866,
+                            "name": "lvm2-lvmpolld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 867,
+                            "name": "lvm2-monitor",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 868,
+                            "name": "lvm2-pvscan@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 869,
+                            "name": "microcode",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 870,
+                            "name": "plymouth-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 871,
+                            "name": "plymouth-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 872,
+                            "name": "plymouth-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 873,
+                            "name": "plymouth-quit-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 874,
+                            "name": "plymouth-quit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 875,
+                            "name": "plymouth-read-write",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 876,
+                            "name": "plymouth-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 877,
+                            "name": "plymouth-start",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 878,
+                            "name": "plymouth-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 879,
+                            "name": "polkit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 880,
+                            "name": "postfix",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 881,
+                            "name": "quotaon",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 882,
+                            "name": "rc-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 883,
+                            "name": "rdisc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 884,
+                            "name": "rescue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 885,
+                            "name": "rhel-autorelabel-mark",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 886,
+                            "name": "rhel-autorelabel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 887,
+                            "name": "rhel-configure",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 888,
+                            "name": "rhel-dmesg",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 889,
+                            "name": "rhel-domainname",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 890,
+                            "name": "rhel-import-state",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 891,
+                            "name": "rhel-loadmodules",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 892,
+                            "name": "rhel-readonly",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 893,
+                            "name": "rsyslog",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 894,
+                            "name": "selinux-policy-migrate-local-changes@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 895,
+                            "name": "serial-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 896,
+                            "name": "sshd-keygen",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 897,
+                            "name": "sshd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 898,
+                            "name": "sshd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 899,
+                            "name": "systemd-ask-password-console",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 900,
+                            "name": "systemd-ask-password-plymouth",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 901,
+                            "name": "systemd-ask-password-wall",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 902,
+                            "name": "systemd-backlight@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 903,
+                            "name": "systemd-binfmt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 904,
+                            "name": "systemd-bootchart",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 905,
+                            "name": "systemd-firstboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 906,
+                            "name": "systemd-fsck-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 907,
+                            "name": "systemd-fsck@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 908,
+                            "name": "systemd-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 909,
+                            "name": "systemd-hibernate-resume@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 910,
+                            "name": "systemd-hibernate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 911,
+                            "name": "systemd-hostnamed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 912,
+                            "name": "systemd-hwdb-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 913,
+                            "name": "systemd-hybrid-sleep",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 914,
+                            "name": "systemd-importd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 915,
+                            "name": "systemd-initctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 916,
+                            "name": "systemd-journal-catalog-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 917,
+                            "name": "systemd-journal-flush",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 918,
+                            "name": "systemd-journald",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 919,
+                            "name": "systemd-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 920,
+                            "name": "systemd-localed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 921,
+                            "name": "systemd-logind",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 922,
+                            "name": "systemd-machine-id-commit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 923,
+                            "name": "systemd-machined",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 924,
+                            "name": "systemd-modules-load",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 925,
+                            "name": "systemd-nspawn@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 926,
+                            "name": "systemd-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 927,
+                            "name": "systemd-quotacheck",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 928,
+                            "name": "systemd-random-seed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 929,
+                            "name": "systemd-readahead-collect",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 930,
+                            "name": "systemd-readahead-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 931,
+                            "name": "systemd-readahead-drop",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 932,
+                            "name": "systemd-readahead-replay",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 933,
+                            "name": "systemd-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 934,
+                            "name": "systemd-remount-fs",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 935,
+                            "name": "systemd-rfkill@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 936,
+                            "name": "systemd-shutdownd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 937,
+                            "name": "systemd-suspend",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 938,
+                            "name": "systemd-sysctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 939,
+                            "name": "systemd-timedated",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 940,
+                            "name": "systemd-tmpfiles-clean",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 941,
+                            "name": "systemd-tmpfiles-setup-dev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 942,
+                            "name": "systemd-tmpfiles-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 943,
+                            "name": "systemd-udev-settle",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 944,
+                            "name": "systemd-udev-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 945,
+                            "name": "systemd-udevd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 946,
+                            "name": "systemd-update-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 947,
+                            "name": "systemd-update-utmp-runlevel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 948,
+                            "name": "systemd-update-utmp",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 949,
+                            "name": "systemd-user-sessions",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 950,
+                            "name": "systemd-vconsole-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 951,
+                            "name": "teamd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 952,
+                            "name": "tuned",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 953,
+                            "name": "vgauthd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 954,
+                            "name": "vmtoolsd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 955,
+                            "name": "wpa_supplicant",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 956,
+                            "name": "systemd-exit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 957,
+                            "name": "functions",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 958,
+                            "name": "netconsole",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 959,
+                            "name": "network",
+                            "typename": "linux_initprocess"
+                        }
+                    ]
+                },
+                {
+                    "id": 7,
+                    "name": "lb",
+                    "description": null,
+                    "type": "ManageIQ::Providers::Vmware::InfraManager::Vm",
+                    "uid_ems": "4219c9b9-d4e9-78b8-5027-fd6379abe169",
+                    "cpu_cores_per_socket": 1,
+                    "cpu_total_cores": 1,
+                    "disks_aligned": "True",
+                    "ems_ref": "vm-225",
+                    "has_rdm_disk": false,
+                    "host": {
+                        "ems_ref": "host-47"
+                    },
+                    "power_state": "on",
+                    "ram_size_in_bytes": 2147483648,
+                    "retired": null,
+                    "v_datastore_path": "NFS-Storage/lb_1/lb.vmx",
+                    "operating_system": {
+                        "product_type": "Linux",
+                        "product_name": "Red Hat Enterprise Linux Server release 7.6 (Maipo)",
+                        "distribution": "redhat"
+                    },
+                    "hardware": {
+                        "id": 11,
+                        "guest_os_full_name": "Red Hat Enterprise Linux 7 (64-bit)",
+                        "disks": [
+                            {
+                                "id": 29,
+                                "device_name": "disk",
+                                "device_type": "floppy",
+                                "disk_type": null,
+                                "filename": "[NFS-Storage] lb_1/",
+                                "free_space": null,
+                                "mode": null,
+                                "size": null,
+                                "size_on_disk": null
+                            },
+                            {
+                                "id": 14,
+                                "device_name": "Hard disk 1",
+                                "device_type": "disk",
+                                "disk_type": "thin",
+                                "filename": "[NFS-Storage] tomcat/tomcat.vmdk",
+                                "free_space": null,
+                                "mode": "persistent",
+                                "size": 4294967296,
+                                "size_on_disk": 2620260352
+                            }
+                        ],
+                        "nics": [
+                            {
+                                "id": 20,
+                                "device_name": "Network adapter 2",
+                                "device_type": "ethernet",
+                                "address": "00:50:56:99:54:c3",
+                                "model": "VirtualVmxnet3",
+                                "uid_ems": "00:50:56:99:54:c3",
+                                "network": null
+                            },
+                            {
+                                "id": 19,
+                                "device_name": "Network adapter 1",
+                                "device_type": "ethernet",
+                                "address": "00:50:56:99:16:dc",
+                                "model": "VirtualVmxnet3",
+                                "uid_ems": "00:50:56:99:16:dc",
+                                "network": {
+                                    "id": 24,
+                                    "ipaddress": "10.10.0.100",
+                                    "hostname": "lb.example.com"
+                                }
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "id": 134,
+                            "name": "/etc/GeoIP.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 135,
+                            "name": "/etc/asound.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 136,
+                            "name": "/etc/chrony.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 137,
+                            "name": "/etc/dracut.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 138,
+                            "name": "/etc/e2fsck.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 139,
+                            "name": "/etc/elinks.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 140,
+                            "name": "/etc/fuse.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 141,
+                            "name": "/etc/host.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 142,
+                            "name": "/etc/kdump.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 143,
+                            "name": "/etc/krb5.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 144,
+                            "name": "/etc/ld.so.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 145,
+                            "name": "/etc/libaudit.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 146,
+                            "name": "/etc/libuser.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 147,
+                            "name": "/etc/locale.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 148,
+                            "name": "/etc/logrotate.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 149,
+                            "name": "/etc/man_db.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 150,
+                            "name": "/etc/mke2fs.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 151,
+                            "name": "/etc/nsswitch.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 152,
+                            "name": "/etc/resolv.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 153,
+                            "name": "/etc/rsyslog.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 154,
+                            "name": "/etc/sestatus.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 155,
+                            "name": "/etc/sudo-ldap.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 156,
+                            "name": "/etc/sudo.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 157,
+                            "name": "/etc/sysctl.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 158,
+                            "name": "/etc/vconsole.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 159,
+                            "name": "/etc/yum.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 160,
+                            "name": "/etc/group",
+                            "contents": "root:x:0:\nbin:x:1:\ndaemon:x:2:\nsys:x:3:\nadm:x:4:\ntty:x:5:\ndisk:x:6:\nlp:x:7:\nmem:x:8:\nkmem:x:9:\nwheel:x:10:\ncdrom:x:11:\nmail:x:12:postfix\nman:x:15:\ndialout:x:18:\nfloppy:x:19:\ngames:x:20:\ntape:x:33:\nvideo:x:39:\nftp:x:50:\nlock:x:54:\naudio:x:63:\nnobody:x:99:\nusers:x:100:\nutmp:x:22:\nutempter:x:35:\ninput:x:999:\nsystemd-journal:x:190:\nsystemd-network:x:192:\ndbus:x:81:\npolkitd:x:998:\nssh_keys:x:997:\npostdrop:x:90:\npostfix:x:89:\nsshd:x:74:\nchrony:x:996:\nnginx:x:995:\ncgred:x:994:\napache:x:48:\n"
+                        },
+                        {
+                            "id": 161,
+                            "name": "/etc/hosts",
+                            "contents": null
+                        }
+                    ],
+                    "system_services": [
+                        {
+                            "id": 780,
+                            "name": "systemd-journald",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 680,
+                            "name": "NetworkManager-dispatcher",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 681,
+                            "name": "NetworkManager-wait-online",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 682,
+                            "name": "NetworkManager",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 683,
+                            "name": "auditd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 684,
+                            "name": "blk-availability",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 685,
+                            "name": "brandbot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 686,
+                            "name": "chrony-dnssrv@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 687,
+                            "name": "chrony-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 688,
+                            "name": "chronyd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 689,
+                            "name": "console-getty",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 690,
+                            "name": "console-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 691,
+                            "name": "container-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 692,
+                            "name": "cpupower",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 693,
+                            "name": "crond",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 694,
+                            "name": "dbus",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 695,
+                            "name": "debug-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 696,
+                            "name": "dm-event",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 697,
+                            "name": "dracut-cmdline",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 698,
+                            "name": "dracut-initqueue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 699,
+                            "name": "dracut-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 700,
+                            "name": "dracut-pre-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 701,
+                            "name": "dracut-pre-pivot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 702,
+                            "name": "dracut-pre-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 703,
+                            "name": "dracut-pre-udev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 704,
+                            "name": "dracut-shutdown",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 705,
+                            "name": "ebtables",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 706,
+                            "name": "emergency",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 707,
+                            "name": "firewalld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 708,
+                            "name": "fstrim",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 709,
+                            "name": "getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 710,
+                            "name": "halt-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 711,
+                            "name": "initrd-cleanup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 712,
+                            "name": "initrd-parse-etc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 713,
+                            "name": "initrd-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 714,
+                            "name": "initrd-udevadm-cleanup-db",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 715,
+                            "name": "iprdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 716,
+                            "name": "iprinit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 717,
+                            "name": "iprupdate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 718,
+                            "name": "irqbalance",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 719,
+                            "name": "jbcs-httpd24-htcacheclean",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 720,
+                            "name": "jbcs-httpd24-httpd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 721,
+                            "name": "kdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 722,
+                            "name": "kmod-static-nodes",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 723,
+                            "name": "lvm2-lvmetad",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 724,
+                            "name": "lvm2-lvmpolld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 725,
+                            "name": "lvm2-monitor",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 726,
+                            "name": "lvm2-pvscan@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 727,
+                            "name": "microcode",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 728,
+                            "name": "plymouth-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 729,
+                            "name": "plymouth-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 730,
+                            "name": "plymouth-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 731,
+                            "name": "plymouth-quit-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 732,
+                            "name": "plymouth-quit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 733,
+                            "name": "plymouth-read-write",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 734,
+                            "name": "plymouth-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 735,
+                            "name": "plymouth-start",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 736,
+                            "name": "plymouth-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 737,
+                            "name": "polkit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 738,
+                            "name": "postfix",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 739,
+                            "name": "qemu-guest-agent",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 740,
+                            "name": "quotaon",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 741,
+                            "name": "rc-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 742,
+                            "name": "rdisc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 743,
+                            "name": "rescue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 744,
+                            "name": "rhel-autorelabel-mark",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 745,
+                            "name": "rhel-autorelabel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 746,
+                            "name": "rhel-configure",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 747,
+                            "name": "rhel-dmesg",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 748,
+                            "name": "rhel-domainname",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 749,
+                            "name": "rhel-import-state",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 750,
+                            "name": "rhel-loadmodules",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 751,
+                            "name": "rhel-readonly",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 752,
+                            "name": "rhsm-facts",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 753,
+                            "name": "rhsm",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 754,
+                            "name": "rhsmcertd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 755,
+                            "name": "rsyslog",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 756,
+                            "name": "selinux-policy-migrate-local-changes@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 757,
+                            "name": "serial-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 758,
+                            "name": "sshd-keygen",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 759,
+                            "name": "sshd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 760,
+                            "name": "sshd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 761,
+                            "name": "systemd-ask-password-console",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 762,
+                            "name": "systemd-ask-password-plymouth",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 763,
+                            "name": "systemd-ask-password-wall",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 764,
+                            "name": "systemd-backlight@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 765,
+                            "name": "systemd-binfmt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 766,
+                            "name": "systemd-bootchart",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 767,
+                            "name": "systemd-firstboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 768,
+                            "name": "systemd-fsck-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 769,
+                            "name": "systemd-fsck@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 770,
+                            "name": "systemd-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 771,
+                            "name": "systemd-hibernate-resume@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 772,
+                            "name": "systemd-hibernate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 773,
+                            "name": "systemd-hostnamed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 774,
+                            "name": "systemd-hwdb-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 775,
+                            "name": "systemd-hybrid-sleep",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 776,
+                            "name": "systemd-importd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 777,
+                            "name": "systemd-initctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 778,
+                            "name": "systemd-journal-catalog-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 779,
+                            "name": "systemd-journal-flush",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 781,
+                            "name": "systemd-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 782,
+                            "name": "systemd-localed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 783,
+                            "name": "systemd-logind",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 784,
+                            "name": "systemd-machine-id-commit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 785,
+                            "name": "systemd-machined",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 786,
+                            "name": "systemd-modules-load",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 787,
+                            "name": "systemd-nspawn@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 788,
+                            "name": "systemd-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 789,
+                            "name": "systemd-quotacheck",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 790,
+                            "name": "systemd-random-seed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 791,
+                            "name": "systemd-readahead-collect",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 792,
+                            "name": "systemd-readahead-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 793,
+                            "name": "systemd-readahead-drop",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 794,
+                            "name": "systemd-readahead-replay",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 795,
+                            "name": "systemd-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 796,
+                            "name": "systemd-remount-fs",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 797,
+                            "name": "systemd-rfkill@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 798,
+                            "name": "systemd-shutdownd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 799,
+                            "name": "systemd-suspend",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 800,
+                            "name": "systemd-sysctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 801,
+                            "name": "systemd-timedated",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 802,
+                            "name": "systemd-tmpfiles-clean",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 803,
+                            "name": "systemd-tmpfiles-setup-dev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 804,
+                            "name": "systemd-tmpfiles-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 805,
+                            "name": "systemd-udev-settle",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 806,
+                            "name": "systemd-udev-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 807,
+                            "name": "systemd-udevd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 808,
+                            "name": "systemd-update-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 809,
+                            "name": "systemd-update-utmp-runlevel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 810,
+                            "name": "systemd-update-utmp",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 811,
+                            "name": "systemd-user-sessions",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 812,
+                            "name": "systemd-vconsole-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 813,
+                            "name": "teamd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 814,
+                            "name": "tuned",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 815,
+                            "name": "vgauthd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 816,
+                            "name": "vmtoolsd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 817,
+                            "name": "wpa_supplicant",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 818,
+                            "name": "systemd-exit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 819,
+                            "name": "functions",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 820,
+                            "name": "netconsole",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 821,
+                            "name": "network",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 822,
+                            "name": "rhnsd",
+                            "typename": "linux_initprocess"
+                        }
+                    ]
+                },
+                {
+                    "id": 13,
+                    "name": "mssql_db",
+                    "description": null,
+                    "type": "ManageIQ::Providers::Vmware::InfraManager::Vm",
+                    "uid_ems": "420a1b8d-d6ba-cebc-7dc5-711fbdeda721",
+                    "cpu_cores_per_socket": 1,
+                    "cpu_total_cores": 2,
+                    "disks_aligned": "True",
+                    "ems_ref": "vm-381",
+                    "has_rdm_disk": false,
+                    "host": {
+                        "ems_ref": "host-47"
+                    },
+                    "power_state": "on",
+                    "ram_size_in_bytes": 4294967296,
+                    "retired": null,
+                    "v_datastore_path": "NFS-Storage/mssql_db/mssql_db.vmx",
+                    "operating_system": {
+                        "product_type": "Linux",
+                        "product_name": "Red Hat Enterprise Linux Server release 7.6 (Maipo)",
+                        "distribution": "redhat"
+                    },
+                    "hardware": {
+                        "id": 16,
+                        "guest_os_full_name": "Red Hat Enterprise Linux 7 (64-bit)",
+                        "disks": [
+                            {
+                                "id": 23,
+                                "device_name": "Hard disk 1",
+                                "device_type": "disk",
+                                "disk_type": "thin",
+                                "filename": "[NFS-Storage] mssql_db/mssql_db.vmdk",
+                                "free_space": null,
+                                "mode": "persistent",
+                                "size": 21474836480,
+                                "size_on_disk": 3316088832
+                            }
+                        ],
+                        "nics": [
+                            {
+                                "id": 23,
+                                "device_name": "Network adapter 1",
+                                "device_type": "ethernet",
+                                "address": "00:50:56:8a:ca:a8",
+                                "model": "VirtualVmxnet3",
+                                "uid_ems": "00:50:56:8a:ca:a8",
+                                "network": {
+                                    "id": 28,
+                                    "ipaddress": "10.10.0.190",
+                                    "hostname": "mssql"
+                                }
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "id": 189,
+                            "name": "/etc/GeoIP.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 190,
+                            "name": "/etc/asound.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 191,
+                            "name": "/etc/chrony.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 192,
+                            "name": "/etc/dracut.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 193,
+                            "name": "/etc/e2fsck.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 194,
+                            "name": "/etc/fuse.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 195,
+                            "name": "/etc/host.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 196,
+                            "name": "/etc/kdump.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 197,
+                            "name": "/etc/krb5.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 198,
+                            "name": "/etc/ld.so.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 199,
+                            "name": "/etc/libaudit.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 200,
+                            "name": "/etc/libuser.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 201,
+                            "name": "/etc/locale.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 202,
+                            "name": "/etc/logrotate.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 203,
+                            "name": "/etc/man_db.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 204,
+                            "name": "/etc/mke2fs.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 205,
+                            "name": "/etc/nsswitch.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 206,
+                            "name": "/etc/resolv.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 207,
+                            "name": "/etc/rsyslog.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 208,
+                            "name": "/etc/sestatus.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 209,
+                            "name": "/etc/sudo-ldap.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 210,
+                            "name": "/etc/sudo.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 211,
+                            "name": "/etc/sysctl.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 212,
+                            "name": "/etc/vconsole.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 213,
+                            "name": "/etc/yum.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 214,
+                            "name": "/etc/group",
+                            "contents": "root:x:0:\nbin:x:1:\ndaemon:x:2:\nsys:x:3:\nadm:x:4:\ntty:x:5:\ndisk:x:6:\nlp:x:7:\nmem:x:8:\nkmem:x:9:\nwheel:x:10:\ncdrom:x:11:\nmail:x:12:postfix\nman:x:15:\ndialout:x:18:\nfloppy:x:19:\ngames:x:20:\ntape:x:33:\nvideo:x:39:\nftp:x:50:\nlock:x:54:\naudio:x:63:\nnobody:x:99:\nusers:x:100:\nutmp:x:22:\nutempter:x:35:\ninput:x:999:\nsystemd-journal:x:190:\nsystemd-network:x:192:\ndbus:x:81:\npolkitd:x:998:\nssh_keys:x:997:\nsshd:x:74:\npostdrop:x:90:\npostfix:x:89:\nchrony:x:996:\nsaslauth:x:76:\nmssql:x:995:\n"
+                        },
+                        {
+                            "id": 215,
+                            "name": "/etc/hosts",
+                            "contents": null
+                        },
+                        {
+                            "id": 216,
+                            "name": "/opt/mssql/bin/mssql-conf",
+                            "contents": null
+                        }
+                    ],
+                    "system_services": [
+                        {
+                            "id": 960,
+                            "name": "NetworkManager-dispatcher",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 961,
+                            "name": "NetworkManager-wait-online",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 962,
+                            "name": "NetworkManager",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 963,
+                            "name": "auditd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 964,
+                            "name": "blk-availability",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 965,
+                            "name": "brandbot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 966,
+                            "name": "chrony-dnssrv@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 967,
+                            "name": "chrony-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 968,
+                            "name": "chronyd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 969,
+                            "name": "console-getty",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 970,
+                            "name": "console-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 971,
+                            "name": "container-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 972,
+                            "name": "cpupower",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 973,
+                            "name": "crond",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 974,
+                            "name": "dbus",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 975,
+                            "name": "debug-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 976,
+                            "name": "dm-event",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 977,
+                            "name": "dracut-cmdline",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 978,
+                            "name": "dracut-initqueue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 979,
+                            "name": "dracut-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 980,
+                            "name": "dracut-pre-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 981,
+                            "name": "dracut-pre-pivot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 982,
+                            "name": "dracut-pre-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 983,
+                            "name": "dracut-pre-udev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 984,
+                            "name": "dracut-shutdown",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 985,
+                            "name": "ebtables",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 986,
+                            "name": "emergency",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 987,
+                            "name": "firewalld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 988,
+                            "name": "fstrim",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 989,
+                            "name": "getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 990,
+                            "name": "halt-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 991,
+                            "name": "initrd-cleanup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 992,
+                            "name": "initrd-parse-etc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 993,
+                            "name": "initrd-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 994,
+                            "name": "initrd-udevadm-cleanup-db",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 995,
+                            "name": "iprdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 996,
+                            "name": "iprinit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 997,
+                            "name": "iprupdate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 998,
+                            "name": "irqbalance",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 999,
+                            "name": "kdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1000,
+                            "name": "kmod-static-nodes",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1001,
+                            "name": "lvm2-lvmetad",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1002,
+                            "name": "lvm2-lvmpolld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1003,
+                            "name": "lvm2-monitor",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1004,
+                            "name": "lvm2-pvscan@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1005,
+                            "name": "microcode",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1006,
+                            "name": "mssql-server",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1007,
+                            "name": "plymouth-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1008,
+                            "name": "plymouth-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1009,
+                            "name": "plymouth-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1010,
+                            "name": "plymouth-quit-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1011,
+                            "name": "plymouth-quit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1012,
+                            "name": "plymouth-read-write",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1013,
+                            "name": "plymouth-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1014,
+                            "name": "plymouth-start",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1015,
+                            "name": "plymouth-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1016,
+                            "name": "polkit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1017,
+                            "name": "postfix",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1018,
+                            "name": "quotaon",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1019,
+                            "name": "rc-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1020,
+                            "name": "rdisc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1021,
+                            "name": "rescue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1022,
+                            "name": "rhel-autorelabel-mark",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1023,
+                            "name": "rhel-autorelabel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1024,
+                            "name": "rhel-configure",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1025,
+                            "name": "rhel-dmesg",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1026,
+                            "name": "rhel-domainname",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1027,
+                            "name": "rhel-import-state",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1028,
+                            "name": "rhel-loadmodules",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1029,
+                            "name": "rhel-readonly",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1030,
+                            "name": "rhsm-facts",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1031,
+                            "name": "rhsm",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1032,
+                            "name": "rhsmcertd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1033,
+                            "name": "rsyslog",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1034,
+                            "name": "saslauthd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1035,
+                            "name": "selinux-policy-migrate-local-changes@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1036,
+                            "name": "serial-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1037,
+                            "name": "sshd-keygen",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1038,
+                            "name": "sshd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1039,
+                            "name": "sshd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1040,
+                            "name": "systemd-ask-password-console",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1041,
+                            "name": "systemd-ask-password-plymouth",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1042,
+                            "name": "systemd-ask-password-wall",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1043,
+                            "name": "systemd-backlight@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1044,
+                            "name": "systemd-binfmt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1045,
+                            "name": "systemd-bootchart",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1046,
+                            "name": "systemd-firstboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1047,
+                            "name": "systemd-fsck-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1048,
+                            "name": "systemd-fsck@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1049,
+                            "name": "systemd-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1050,
+                            "name": "systemd-hibernate-resume@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1051,
+                            "name": "systemd-hibernate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1052,
+                            "name": "systemd-hostnamed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1053,
+                            "name": "systemd-hwdb-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1054,
+                            "name": "systemd-hybrid-sleep",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1055,
+                            "name": "systemd-importd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1056,
+                            "name": "systemd-initctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1057,
+                            "name": "systemd-journal-catalog-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1058,
+                            "name": "systemd-journal-flush",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1059,
+                            "name": "systemd-journald",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1060,
+                            "name": "systemd-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1061,
+                            "name": "systemd-localed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1062,
+                            "name": "systemd-logind",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1063,
+                            "name": "systemd-machine-id-commit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1064,
+                            "name": "systemd-machined",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1065,
+                            "name": "systemd-modules-load",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1066,
+                            "name": "systemd-nspawn@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1067,
+                            "name": "systemd-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1068,
+                            "name": "systemd-quotacheck",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1069,
+                            "name": "systemd-random-seed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1070,
+                            "name": "systemd-readahead-collect",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1071,
+                            "name": "systemd-readahead-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1072,
+                            "name": "systemd-readahead-drop",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1073,
+                            "name": "systemd-readahead-replay",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1074,
+                            "name": "systemd-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1075,
+                            "name": "systemd-remount-fs",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1076,
+                            "name": "systemd-rfkill@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1077,
+                            "name": "systemd-shutdownd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1078,
+                            "name": "systemd-suspend",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1079,
+                            "name": "systemd-sysctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1080,
+                            "name": "systemd-timedated",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1081,
+                            "name": "systemd-tmpfiles-clean",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1082,
+                            "name": "systemd-tmpfiles-setup-dev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1083,
+                            "name": "systemd-tmpfiles-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1084,
+                            "name": "systemd-udev-settle",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1085,
+                            "name": "systemd-udev-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1086,
+                            "name": "systemd-udevd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1087,
+                            "name": "systemd-update-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1088,
+                            "name": "systemd-update-utmp-runlevel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1089,
+                            "name": "systemd-update-utmp",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1090,
+                            "name": "systemd-user-sessions",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1091,
+                            "name": "systemd-vconsole-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1092,
+                            "name": "teamd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1093,
+                            "name": "tuned",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1094,
+                            "name": "vgauthd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1095,
+                            "name": "vmtoolsd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1096,
+                            "name": "wpa_supplicant",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1097,
+                            "name": "systemd-exit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1098,
+                            "name": "functions",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 1099,
+                            "name": "netconsole",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 1100,
+                            "name": "network",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 1101,
+                            "name": "rhnsd",
+                            "typename": "linux_initprocess"
+                        }
+                    ]
+                },
+                {
+                    "id": 12,
+                    "name": "oracle_db",
+                    "description": null,
+                    "type": "ManageIQ::Providers::Vmware::InfraManager::Vm",
+                    "uid_ems": "420a7888-88ee-44c9-551a-6589f883a282",
+                    "cpu_cores_per_socket": 1,
+                    "cpu_total_cores": 2,
+                    "disks_aligned": "True",
+                    "ems_ref": "vm-361",
+                    "has_rdm_disk": false,
+                    "host": {
+                        "ems_ref": "host-47"
+                    },
+                    "power_state": "on",
+                    "ram_size_in_bytes": 8589934592,
+                    "retired": null,
+                    "v_datastore_path": "NFS-Storage/oracle_db_1/oracle_db.vmx",
+                    "operating_system": {
+                        "product_type": "Linux",
+                        "product_name": "CentOS Linux release 7.6.1810 (Core) ",
+                        "distribution": "CentOS"
+                    },
+                    "hardware": {
+                        "id": 15,
+                        "guest_os_full_name": "CentOS 4/5 or later (64-bit)",
+                        "disks": [
+                            {
+                                "id": 30,
+                                "device_name": "disk",
+                                "device_type": "floppy",
+                                "disk_type": null,
+                                "filename": "[NFS-Storage] oracle_db_1/",
+                                "free_space": null,
+                                "mode": null,
+                                "size": null,
+                                "size_on_disk": null
+                            },
+                            {
+                                "id": 21,
+                                "device_name": "Hard disk 1",
+                                "device_type": "disk",
+                                "disk_type": "thin",
+                                "filename": "[NFS-Storage] oracle_db_1/oracle_db.vmdk",
+                                "free_space": null,
+                                "mode": "persistent",
+                                "size": 21474836480,
+                                "size_on_disk": 17980588032
+                            },
+                            {
+                                "id": 20,
+                                "device_name": "CD/DVD drive 1",
+                                "device_type": "cdrom-raw",
+                                "disk_type": null,
+                                "filename": "[NFS-Storage] oracle_db_1/",
+                                "free_space": null,
+                                "mode": null,
+                                "size": null,
+                                "size_on_disk": null
+                            }
+                        ],
+                        "nics": [
+                            {
+                                "id": 22,
+                                "device_name": "Network adapter 1",
+                                "device_type": "ethernet",
+                                "address": "00:50:56:8a:31:ae",
+                                "model": "VirtualVmxnet3",
+                                "uid_ems": "00:50:56:8a:31:ae",
+                                "network": {
+                                    "id": 26,
+                                    "ipaddress": "10.10.0.160",
+                                    "hostname": "oracledb.example.com"
+                                }
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "id": 217,
+                            "name": "/etc/GeoIP.conf",
+                            "contents": "dummy content"
+                        },
+                        {
+                            "id": 218,
+                            "name": "/etc/asound.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 219,
+                            "name": "/etc/autofs.conf",
+                            "contents": null
+                        }
+                    ],
+                    "system_services": [
+                        {
+                            "id": 1102,
+                            "name": "NetworkManager-dispatcher",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1103,
+                            "name": "NetworkManager-wait-online",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 1104,
+                            "name": "NetworkManager",
+                            "typename": "linux_systemd"
+                        }
+                    ]
+                },
+                {
+                    "id": 8,
+                    "name": "jboss1",
+                    "description": null,
+                    "type": "ManageIQ::Providers::Vmware::InfraManager::Vm",
+                    "uid_ems": "564dc5fd-8fb4-a234-96d3-ae6834707d70",
+                    "cpu_cores_per_socket": 1,
+                    "cpu_total_cores": 1,
+                    "disks_aligned": "True",
+                    "ems_ref": "vm-224",
+                    "has_rdm_disk": false,
+                    "host": {
+                        "ems_ref": "host-47"
+                    },
+                    "power_state": "on",
+                    "ram_size_in_bytes": 2147483648,
+                    "retired": null,
+                    "v_datastore_path": "NFS-Storage/jboss1/jboss1.vmx",
+                    "operating_system": {
+                        "product_type": "Linux",
+                        "product_name": "Red Hat Enterprise Linux Server release 7.6 (Maipo)",
+                        "distribution": "redhat"
+                    },
+                    "hardware": {
+                        "id": 12,
+                        "guest_os_full_name": "Red Hat Enterprise Linux 7 (64-bit)",
+                        "disks": [
+                            {
+                                "id": 28,
+                                "device_name": "disk",
+                                "device_type": "floppy",
+                                "disk_type": null,
+                                "filename": "[NFS-Storage] jboss1/",
+                                "free_space": null,
+                                "mode": null,
+                                "size": null,
+                                "size_on_disk": null
+                            },
+                            {
+                                "id": 16,
+                                "device_name": "Hard disk 1",
+                                "device_type": "disk",
+                                "disk_type": "thin",
+                                "filename": "[NFS-Storage] jboss1/jboss1.vmdk",
+                                "free_space": null,
+                                "mode": "persistent",
+                                "size": 17179869184,
+                                "size_on_disk": 4833341440
+                            }
+                        ],
+                        "nics": [
+                            {
+                                "id": 21,
+                                "device_name": "Network adapter 1",
+                                "device_type": "ethernet",
+                                "address": "00:50:56:99:59:73",
+                                "model": "VirtualVmxnet3",
+                                "uid_ems": "00:50:56:99:59:73",
+                                "network": {
+                                    "id": 21,
+                                    "ipaddress": "\"10.10.0.111\"",
+                                    "hostname": "jboss1.example.com"
+                                }
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "id": 104,
+                            "name": "/etc/GeoIP.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 105,
+                            "name": "/etc/asound.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 106,
+                            "name": "/etc/chrony.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 107,
+                            "name": "/etc/dnsmasq.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 108,
+                            "name": "/etc/dracut.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 109,
+                            "name": "/etc/e2fsck.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 110,
+                            "name": "/etc/fuse.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 111,
+                            "name": "/etc/host.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 112,
+                            "name": "/etc/kdump.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 113,
+                            "name": "/etc/krb5.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 114,
+                            "name": "/etc/ld.so.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 115,
+                            "name": "/etc/libaudit.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 116,
+                            "name": "/etc/libuser.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 117,
+                            "name": "/etc/locale.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 118,
+                            "name": "/etc/logrotate.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 119,
+                            "name": "/etc/man_db.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 120,
+                            "name": "/etc/mke2fs.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 121,
+                            "name": "/etc/nsswitch.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 122,
+                            "name": "/etc/resolv.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 123,
+                            "name": "/etc/rsyncd.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 124,
+                            "name": "/etc/rsyslog.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 125,
+                            "name": "/etc/sestatus.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 126,
+                            "name": "/etc/sudo-ldap.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 127,
+                            "name": "/etc/sudo.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 128,
+                            "name": "/etc/sysctl.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 129,
+                            "name": "/etc/tcsd.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 130,
+                            "name": "/etc/vconsole.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 131,
+                            "name": "/etc/yum.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 132,
+                            "name": "/etc/group",
+                            "contents": "root:x:0:\nbin:x:1:\ndaemon:x:2:\nsys:x:3:\nadm:x:4:\ntty:x:5:\ndisk:x:6:\nlp:x:7:\nmem:x:8:\nkmem:x:9:\nwheel:x:10:\ncdrom:x:11:\nmail:x:12:postfix\nman:x:15:\ndialout:x:18:\nfloppy:x:19:\ngames:x:20:\ntape:x:30:\nvideo:x:39:\nftp:x:50:\nlock:x:54:\naudio:x:63:\nnobody:x:99:\nusers:x:100:\nutmp:x:22:\nutempter:x:35:\nssh_keys:x:999:\ninput:x:998:\nsystemd-journal:x:190:\nsystemd-bus-proxy:x:997:\nsystemd-network:x:192:\ndbus:x:81:\npolkitd:x:996:\ndip:x:40:\ntss:x:59:\npostdrop:x:90:\npostfix:x:89:\nsshd:x:74:\nchrony:x:995:\njboss:x:185:\n"
+                        },
+                        {
+                            "id": 133,
+                            "name": "/etc/hosts",
+                            "contents": null
+                        }
+                    ],
+                    "system_services": [
+                        {
+                            "id": 529,
+                            "name": "NetworkManager-dispatcher",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 530,
+                            "name": "NetworkManager-wait-online",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 531,
+                            "name": "NetworkManager",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 532,
+                            "name": "arp-ethers",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 533,
+                            "name": "auditd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 534,
+                            "name": "blk-availability",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 535,
+                            "name": "brandbot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 536,
+                            "name": "chrony-dnssrv@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 537,
+                            "name": "chrony-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 538,
+                            "name": "chronyd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 539,
+                            "name": "console-getty",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 540,
+                            "name": "console-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 541,
+                            "name": "container-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 542,
+                            "name": "cpupower",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 543,
+                            "name": "crond",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 544,
+                            "name": "dbus",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 545,
+                            "name": "debug-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 546,
+                            "name": "dm-event",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 547,
+                            "name": "dnsmasq",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 548,
+                            "name": "dracut-cmdline",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 549,
+                            "name": "dracut-initqueue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 550,
+                            "name": "dracut-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 551,
+                            "name": "dracut-pre-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 552,
+                            "name": "dracut-pre-pivot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 553,
+                            "name": "dracut-pre-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 554,
+                            "name": "dracut-pre-udev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 555,
+                            "name": "dracut-shutdown",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 556,
+                            "name": "eap7-domain",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 557,
+                            "name": "eap7-standalone",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 558,
+                            "name": "ebtables",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 559,
+                            "name": "emergency",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 560,
+                            "name": "firewalld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 561,
+                            "name": "fstrim",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 562,
+                            "name": "getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 563,
+                            "name": "halt-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 564,
+                            "name": "initrd-cleanup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 565,
+                            "name": "initrd-parse-etc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 566,
+                            "name": "initrd-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 567,
+                            "name": "initrd-udevadm-cleanup-db",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 568,
+                            "name": "iprdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 569,
+                            "name": "iprinit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 570,
+                            "name": "iprupdate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 571,
+                            "name": "irqbalance",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 572,
+                            "name": "kdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 573,
+                            "name": "kmod-static-nodes",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 574,
+                            "name": "lvm2-lvmetad",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 575,
+                            "name": "lvm2-lvmpolld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 576,
+                            "name": "lvm2-monitor",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 577,
+                            "name": "lvm2-pvscan@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 578,
+                            "name": "microcode",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 579,
+                            "name": "plymouth-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 580,
+                            "name": "plymouth-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 581,
+                            "name": "plymouth-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 582,
+                            "name": "plymouth-quit-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 583,
+                            "name": "plymouth-quit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 584,
+                            "name": "plymouth-read-write",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 585,
+                            "name": "plymouth-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 586,
+                            "name": "plymouth-start",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 587,
+                            "name": "plymouth-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 588,
+                            "name": "polkit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 589,
+                            "name": "postfix",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 590,
+                            "name": "quotaon",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 591,
+                            "name": "rc-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 592,
+                            "name": "rdisc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 593,
+                            "name": "rdma-load-modules@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 594,
+                            "name": "rdma-ndd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 595,
+                            "name": "rdma",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 596,
+                            "name": "rescue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 597,
+                            "name": "rhel-autorelabel-mark",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 598,
+                            "name": "rhel-autorelabel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 599,
+                            "name": "rhel-configure",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 600,
+                            "name": "rhel-dmesg",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 601,
+                            "name": "rhel-domainname",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 602,
+                            "name": "rhel-import-state",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 603,
+                            "name": "rhel-loadmodules",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 604,
+                            "name": "rhel-readonly",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 605,
+                            "name": "rhsm-facts",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 606,
+                            "name": "rhsm",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 607,
+                            "name": "rhsmcertd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 608,
+                            "name": "rsyncd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 609,
+                            "name": "rsyncd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 610,
+                            "name": "rsyslog",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 611,
+                            "name": "selinux-policy-migrate-local-changes@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 612,
+                            "name": "serial-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 613,
+                            "name": "sshd-keygen",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 614,
+                            "name": "sshd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 615,
+                            "name": "sshd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 616,
+                            "name": "systemd-ask-password-console",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 617,
+                            "name": "systemd-ask-password-plymouth",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 618,
+                            "name": "systemd-ask-password-wall",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 619,
+                            "name": "systemd-backlight@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 620,
+                            "name": "systemd-binfmt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 621,
+                            "name": "systemd-bootchart",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 622,
+                            "name": "systemd-firstboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 623,
+                            "name": "systemd-fsck-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 624,
+                            "name": "systemd-fsck@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 625,
+                            "name": "systemd-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 626,
+                            "name": "systemd-hibernate-resume@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 627,
+                            "name": "systemd-hibernate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 628,
+                            "name": "systemd-hostnamed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 629,
+                            "name": "systemd-hwdb-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 630,
+                            "name": "systemd-hybrid-sleep",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 631,
+                            "name": "systemd-importd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 632,
+                            "name": "systemd-initctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 633,
+                            "name": "systemd-journal-catalog-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 634,
+                            "name": "systemd-journal-flush",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 635,
+                            "name": "systemd-journald",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 636,
+                            "name": "systemd-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 637,
+                            "name": "systemd-localed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 638,
+                            "name": "systemd-logind",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 639,
+                            "name": "systemd-machine-id-commit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 640,
+                            "name": "systemd-machined",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 641,
+                            "name": "systemd-modules-load",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 642,
+                            "name": "systemd-nspawn@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 643,
+                            "name": "systemd-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 644,
+                            "name": "systemd-quotacheck",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 645,
+                            "name": "systemd-random-seed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 646,
+                            "name": "systemd-readahead-collect",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 647,
+                            "name": "systemd-readahead-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 648,
+                            "name": "systemd-readahead-drop",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 649,
+                            "name": "systemd-readahead-replay",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 650,
+                            "name": "systemd-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 651,
+                            "name": "systemd-remount-fs",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 652,
+                            "name": "systemd-rfkill@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 653,
+                            "name": "systemd-shutdownd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 654,
+                            "name": "systemd-suspend",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 655,
+                            "name": "systemd-sysctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 656,
+                            "name": "systemd-timedated",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 657,
+                            "name": "systemd-tmpfiles-clean",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 658,
+                            "name": "systemd-tmpfiles-setup-dev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 659,
+                            "name": "systemd-tmpfiles-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 660,
+                            "name": "systemd-udev-settle",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 661,
+                            "name": "systemd-udev-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 662,
+                            "name": "systemd-udevd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 663,
+                            "name": "systemd-update-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 664,
+                            "name": "systemd-update-utmp-runlevel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 665,
+                            "name": "systemd-update-utmp",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 666,
+                            "name": "systemd-user-sessions",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 667,
+                            "name": "systemd-vconsole-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 668,
+                            "name": "tcsd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 669,
+                            "name": "teamd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 670,
+                            "name": "tuned",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 671,
+                            "name": "vgauthd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 672,
+                            "name": "vmtoolsd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 673,
+                            "name": "wpa_supplicant",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 674,
+                            "name": "glib-pacrunner",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 675,
+                            "name": "systemd-exit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 676,
+                            "name": "functions",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 677,
+                            "name": "netconsole",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 678,
+                            "name": "network",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 679,
+                            "name": "rhnsd",
+                            "typename": "linux_initprocess"
+                        }
+                    ]
+                },
+                {
+                    "id": 6,
+                    "name": "db",
+                    "description": null,
+                    "type": "ManageIQ::Providers::Vmware::InfraManager::Vm",
+                    "uid_ems": "42195d27-1b8b-80ad-23f5-fa3f91b435de",
+                    "cpu_cores_per_socket": 1,
+                    "cpu_total_cores": 1,
+                    "disks_aligned": "True",
+                    "ems_ref": "vm-222",
+                    "has_rdm_disk": false,
+                    "host": {
+                        "ems_ref": "host-47"
+                    },
+                    "power_state": "on",
+                    "ram_size_in_bytes": 2147483648,
+                    "retired": null,
+                    "v_datastore_path": "NFS-Storage/db_1/db.vmx",
+                    "operating_system": {
+                        "product_type": "Linux",
+                        "product_name": "Red Hat Enterprise Linux Server release 7.6 (Maipo)",
+                        "distribution": "redhat"
+                    },
+                    "hardware": {
+                        "id": 10,
+                        "guest_os_full_name": "Red Hat Enterprise Linux 7 (64-bit)",
+                        "disks": [
+                            {
+                                "id": 25,
+                                "device_name": "disk",
+                                "device_type": "floppy",
+                                "disk_type": null,
+                                "filename": "[NFS-Storage] db_1/",
+                                "free_space": null,
+                                "mode": null,
+                                "size": null,
+                                "size_on_disk": null
+                            },
+                            {
+                                "id": 11,
+                                "device_name": "Hard disk 1",
+                                "device_type": "disk",
+                                "disk_type": "thin",
+                                "filename": "[NFS-Storage] db_1/db.vmdk",
+                                "free_space": null,
+                                "mode": "persistent",
+                                "size": 4294967296,
+                                "size_on_disk": 2674286592
+                            }
+                        ],
+                        "nics": [
+                            {
+                                "id": 18,
+                                "device_name": "Network adapter 1",
+                                "device_type": "ethernet",
+                                "address": "00:50:56:99:a2:0a",
+                                "model": "VirtualVmxnet3",
+                                "uid_ems": "00:50:56:99:a2:0a",
+                                "network": {
+                                    "id": 22,
+                                    "ipaddress": "\"10.10.0.120\"",
+                                    "hostname": "db.example.com"
+                                }
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "id": 1,
+                            "name": "/etc/GeoIP.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 2,
+                            "name": "/etc/asound.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 3,
+                            "name": "/etc/chrony.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 4,
+                            "name": "/etc/dracut.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 5,
+                            "name": "/etc/e2fsck.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 6,
+                            "name": "/etc/fuse.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 7,
+                            "name": "/etc/host.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 8,
+                            "name": "/etc/kdump.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 9,
+                            "name": "/etc/krb5.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 10,
+                            "name": "/etc/ld.so.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 11,
+                            "name": "/etc/libaudit.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 12,
+                            "name": "/etc/libuser.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 13,
+                            "name": "/etc/locale.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 14,
+                            "name": "/etc/logrotate.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 15,
+                            "name": "/etc/man_db.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 16,
+                            "name": "/etc/mke2fs.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 17,
+                            "name": "/etc/nsswitch.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 18,
+                            "name": "/etc/resolv.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 19,
+                            "name": "/etc/rsyslog.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 20,
+                            "name": "/etc/sestatus.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 21,
+                            "name": "/etc/sudo-ldap.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 22,
+                            "name": "/etc/sudo.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 23,
+                            "name": "/etc/sysctl.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 24,
+                            "name": "/etc/vconsole.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 25,
+                            "name": "/etc/yum.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 26,
+                            "name": "/etc/group",
+                            "contents": "root:x:0:\nbin:x:1:\ndaemon:x:2:\nsys:x:3:\nadm:x:4:\ntty:x:5:\ndisk:x:6:\nlp:x:7:\nmem:x:8:\nkmem:x:9:\nwheel:x:10:\ncdrom:x:11:\nmail:x:12:postfix\nman:x:15:\ndialout:x:18:\nfloppy:x:19:\ngames:x:20:\ntape:x:33:\nvideo:x:39:\nftp:x:50:\nlock:x:54:\naudio:x:63:\nnobody:x:99:\nusers:x:100:\nutmp:x:22:\nutempter:x:35:\ninput:x:999:\nsystemd-journal:x:190:\nsystemd-network:x:192:\ndbus:x:81:\npolkitd:x:998:\nssh_keys:x:997:\npostdrop:x:90:\npostfix:x:89:\nsshd:x:74:\nchrony:x:996:\npostgres:x:26:\n"
+                        },
+                        {
+                            "id": 27,
+                            "name": "/etc/hosts",
+                            "contents": null
+                        }
+                    ],
+                    "system_services": [
+                        {
+                            "id": 27,
+                            "name": "NetworkManager-dispatcher",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 28,
+                            "name": "NetworkManager-wait-online",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 29,
+                            "name": "NetworkManager",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 30,
+                            "name": "auditd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 31,
+                            "name": "blk-availability",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 32,
+                            "name": "brandbot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 33,
+                            "name": "chrony-dnssrv@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 34,
+                            "name": "chrony-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 35,
+                            "name": "chronyd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 36,
+                            "name": "console-getty",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 37,
+                            "name": "console-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 38,
+                            "name": "container-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 39,
+                            "name": "cpupower",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 40,
+                            "name": "crond",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 41,
+                            "name": "dbus",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 42,
+                            "name": "debug-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 43,
+                            "name": "dm-event",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 44,
+                            "name": "dracut-cmdline",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 45,
+                            "name": "dracut-initqueue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 46,
+                            "name": "dracut-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 47,
+                            "name": "dracut-pre-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 48,
+                            "name": "dracut-pre-pivot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 49,
+                            "name": "dracut-pre-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 50,
+                            "name": "dracut-pre-udev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 51,
+                            "name": "dracut-shutdown",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 52,
+                            "name": "ebtables",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 53,
+                            "name": "emergency",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 54,
+                            "name": "firewalld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 55,
+                            "name": "fstrim",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 56,
+                            "name": "getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 57,
+                            "name": "halt-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 58,
+                            "name": "initrd-cleanup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 59,
+                            "name": "initrd-parse-etc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 60,
+                            "name": "initrd-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 61,
+                            "name": "initrd-udevadm-cleanup-db",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 62,
+                            "name": "iprdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 63,
+                            "name": "iprinit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 64,
+                            "name": "iprupdate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 65,
+                            "name": "irqbalance",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 66,
+                            "name": "kdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 67,
+                            "name": "kmod-static-nodes",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 68,
+                            "name": "lvm2-lvmetad",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 69,
+                            "name": "lvm2-lvmpolld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 70,
+                            "name": "lvm2-monitor",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 71,
+                            "name": "lvm2-pvscan@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 72,
+                            "name": "microcode",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 73,
+                            "name": "plymouth-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 74,
+                            "name": "plymouth-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 75,
+                            "name": "plymouth-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 76,
+                            "name": "plymouth-quit-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 77,
+                            "name": "plymouth-quit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 78,
+                            "name": "plymouth-read-write",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 79,
+                            "name": "plymouth-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 80,
+                            "name": "plymouth-start",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 81,
+                            "name": "plymouth-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 82,
+                            "name": "polkit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 83,
+                            "name": "postfix",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 84,
+                            "name": "postgresql",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 85,
+                            "name": "qemu-guest-agent",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 86,
+                            "name": "quotaon",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 87,
+                            "name": "rc-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 88,
+                            "name": "rdisc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 89,
+                            "name": "rescue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 90,
+                            "name": "rhel-autorelabel-mark",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 91,
+                            "name": "rhel-autorelabel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 92,
+                            "name": "rhel-configure",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 93,
+                            "name": "rhel-dmesg",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 94,
+                            "name": "rhel-domainname",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 95,
+                            "name": "rhel-import-state",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 96,
+                            "name": "rhel-loadmodules",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 97,
+                            "name": "rhel-readonly",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 98,
+                            "name": "rhsm-facts",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 99,
+                            "name": "rhsm",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 100,
+                            "name": "rhsmcertd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 101,
+                            "name": "rsyslog",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 102,
+                            "name": "selinux-policy-migrate-local-changes@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 103,
+                            "name": "serial-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 104,
+                            "name": "sshd-keygen",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 105,
+                            "name": "sshd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 106,
+                            "name": "sshd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 107,
+                            "name": "systemd-ask-password-console",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 108,
+                            "name": "systemd-ask-password-plymouth",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 109,
+                            "name": "systemd-ask-password-wall",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 110,
+                            "name": "systemd-backlight@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 111,
+                            "name": "systemd-binfmt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 112,
+                            "name": "systemd-bootchart",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 113,
+                            "name": "systemd-firstboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 114,
+                            "name": "systemd-fsck-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 115,
+                            "name": "systemd-fsck@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 116,
+                            "name": "systemd-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 117,
+                            "name": "systemd-hibernate-resume@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 118,
+                            "name": "systemd-hibernate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 119,
+                            "name": "systemd-hostnamed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 120,
+                            "name": "systemd-hwdb-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 121,
+                            "name": "systemd-hybrid-sleep",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 122,
+                            "name": "systemd-importd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 123,
+                            "name": "systemd-initctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 124,
+                            "name": "systemd-journal-catalog-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 125,
+                            "name": "systemd-journal-flush",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 126,
+                            "name": "systemd-journald",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 127,
+                            "name": "systemd-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 128,
+                            "name": "systemd-localed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 129,
+                            "name": "systemd-logind",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 130,
+                            "name": "systemd-machine-id-commit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 131,
+                            "name": "systemd-machined",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 132,
+                            "name": "systemd-modules-load",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 133,
+                            "name": "systemd-nspawn@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 134,
+                            "name": "systemd-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 135,
+                            "name": "systemd-quotacheck",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 136,
+                            "name": "systemd-random-seed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 137,
+                            "name": "systemd-readahead-collect",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 138,
+                            "name": "systemd-readahead-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 139,
+                            "name": "systemd-readahead-drop",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 140,
+                            "name": "systemd-readahead-replay",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 141,
+                            "name": "systemd-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 142,
+                            "name": "systemd-remount-fs",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 143,
+                            "name": "systemd-rfkill@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 144,
+                            "name": "systemd-shutdownd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 145,
+                            "name": "systemd-suspend",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 146,
+                            "name": "systemd-sysctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 147,
+                            "name": "systemd-timedated",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 148,
+                            "name": "systemd-tmpfiles-clean",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 149,
+                            "name": "systemd-tmpfiles-setup-dev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 150,
+                            "name": "systemd-tmpfiles-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 151,
+                            "name": "systemd-udev-settle",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 152,
+                            "name": "systemd-udev-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 153,
+                            "name": "systemd-udevd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 154,
+                            "name": "systemd-update-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 155,
+                            "name": "systemd-update-utmp-runlevel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 156,
+                            "name": "systemd-update-utmp",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 157,
+                            "name": "systemd-user-sessions",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 158,
+                            "name": "systemd-vconsole-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 159,
+                            "name": "teamd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 160,
+                            "name": "tuned",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 161,
+                            "name": "vgauthd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 162,
+                            "name": "vmtoolsd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 163,
+                            "name": "wpa_supplicant",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 164,
+                            "name": "systemd-exit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 165,
+                            "name": "functions",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 166,
+                            "name": "netconsole",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 167,
+                            "name": "network",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 168,
+                            "name": "rhnsd",
+                            "typename": "linux_initprocess"
+                        }
+                    ]
+                },
+                {
+                    "id": 5,
+                    "name": "jboss0",
+                    "description": null,
+                    "type": "ManageIQ::Providers::Vmware::InfraManager::Vm",
+                    "uid_ems": "42196ed8-f41a-d6fd-0b30-7601bd029883",
+                    "cpu_cores_per_socket": 1,
+                    "cpu_total_cores": 1,
+                    "disks_aligned": "True",
+                    "ems_ref": "vm-223",
+                    "has_rdm_disk": false,
+                    "host": {
+                        "ems_ref": "host-31"
+                    },
+                    "power_state": "on",
+                    "ram_size_in_bytes": 2147483648,
+                    "retired": null,
+                    "v_datastore_path": "NFS-Storage/jboss0/jboss0.vmx",
+                    "operating_system": {
+                        "product_type": "Linux",
+                        "product_name": "Red Hat Enterprise Linux Server release 7.6 (Maipo)",
+                        "distribution": "redhat"
+                    },
+                    "hardware": {
+                        "id": 9,
+                        "guest_os_full_name": "Red Hat Enterprise Linux 7 (64-bit)",
+                        "disks": [
+                            {
+                                "id": 27,
+                                "device_name": "disk",
+                                "device_type": "floppy",
+                                "disk_type": null,
+                                "filename": "[NFS-Storage] jboss0/",
+                                "free_space": null,
+                                "mode": null,
+                                "size": null,
+                                "size_on_disk": null
+                            },
+                            {
+                                "id": 7,
+                                "device_name": "Hard disk 1",
+                                "device_type": "disk",
+                                "disk_type": "thin",
+                                "filename": "[NFS-Storage] jboss0/jboss0.vmdk",
+                                "free_space": null,
+                                "mode": "persistent",
+                                "size": 17179869184,
+                                "size_on_disk": 4872695808
+                            }
+                        ],
+                        "nics": [
+                            {
+                                "id": 17,
+                                "device_name": "Network adapter 1",
+                                "device_type": "ethernet",
+                                "address": "00:50:56:99:cb:a3",
+                                "model": "VirtualVmxnet3",
+                                "uid_ems": "00:50:56:99:cb:a3",
+                                "network": {
+                                    "id": 27,
+                                    "ipaddress": "\"10.10.0.110\"",
+                                    "hostname": "jboss0.example.com"
+                                }
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "id": 74,
+                            "name": "/etc/GeoIP.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 75,
+                            "name": "/etc/asound.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 76,
+                            "name": "/etc/chrony.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 77,
+                            "name": "/etc/dnsmasq.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 78,
+                            "name": "/etc/dracut.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 79,
+                            "name": "/etc/e2fsck.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 80,
+                            "name": "/etc/fuse.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 81,
+                            "name": "/etc/host.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 82,
+                            "name": "/etc/kdump.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 83,
+                            "name": "/etc/krb5.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 84,
+                            "name": "/etc/ld.so.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 85,
+                            "name": "/etc/libaudit.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 86,
+                            "name": "/etc/libuser.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 87,
+                            "name": "/etc/locale.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 88,
+                            "name": "/etc/logrotate.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 89,
+                            "name": "/etc/man_db.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 90,
+                            "name": "/etc/mke2fs.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 91,
+                            "name": "/etc/nsswitch.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 92,
+                            "name": "/etc/resolv.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 93,
+                            "name": "/etc/rsyncd.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 94,
+                            "name": "/etc/rsyslog.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 95,
+                            "name": "/etc/sestatus.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 96,
+                            "name": "/etc/sudo-ldap.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 97,
+                            "name": "/etc/sudo.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 98,
+                            "name": "/etc/sysctl.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 99,
+                            "name": "/etc/tcsd.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 100,
+                            "name": "/etc/vconsole.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 101,
+                            "name": "/etc/yum.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 102,
+                            "name": "/etc/group",
+                            "contents": "root:x:0:\nbin:x:1:\ndaemon:x:2:\nsys:x:3:\nadm:x:4:\ntty:x:5:\ndisk:x:6:\nlp:x:7:\nmem:x:8:\nkmem:x:9:\nwheel:x:10:\ncdrom:x:11:\nmail:x:12:postfix\nman:x:15:\ndialout:x:18:\nfloppy:x:19:\ngames:x:20:\ntape:x:30:\nvideo:x:39:\nftp:x:50:\nlock:x:54:\naudio:x:63:\nnobody:x:99:\nusers:x:100:\nutmp:x:22:\nutempter:x:35:\nssh_keys:x:999:\ninput:x:998:\nsystemd-journal:x:190:\nsystemd-bus-proxy:x:997:\nsystemd-network:x:192:\ndbus:x:81:\npolkitd:x:996:\ndip:x:40:\ntss:x:59:\npostdrop:x:90:\npostfix:x:89:\nsshd:x:74:\nchrony:x:995:\njboss:x:185:\n"
+                        },
+                        {
+                            "id": 103,
+                            "name": "/etc/hosts",
+                            "contents": null
+                        }
+                    ],
+                    "system_services": [
+                        {
+                            "id": 378,
+                            "name": "NetworkManager-dispatcher",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 379,
+                            "name": "NetworkManager-wait-online",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 380,
+                            "name": "NetworkManager",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 381,
+                            "name": "arp-ethers",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 382,
+                            "name": "auditd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 383,
+                            "name": "blk-availability",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 384,
+                            "name": "brandbot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 385,
+                            "name": "chrony-dnssrv@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 386,
+                            "name": "chrony-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 387,
+                            "name": "chronyd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 388,
+                            "name": "console-getty",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 389,
+                            "name": "console-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 390,
+                            "name": "container-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 391,
+                            "name": "cpupower",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 392,
+                            "name": "crond",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 393,
+                            "name": "dbus",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 394,
+                            "name": "debug-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 395,
+                            "name": "dm-event",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 396,
+                            "name": "dnsmasq",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 397,
+                            "name": "dracut-cmdline",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 398,
+                            "name": "dracut-initqueue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 399,
+                            "name": "dracut-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 400,
+                            "name": "dracut-pre-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 401,
+                            "name": "dracut-pre-pivot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 402,
+                            "name": "dracut-pre-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 403,
+                            "name": "dracut-pre-udev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 404,
+                            "name": "dracut-shutdown",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 405,
+                            "name": "eap7-domain",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 406,
+                            "name": "eap7-standalone",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 407,
+                            "name": "ebtables",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 408,
+                            "name": "emergency",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 409,
+                            "name": "firewalld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 410,
+                            "name": "fstrim",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 411,
+                            "name": "getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 412,
+                            "name": "halt-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 413,
+                            "name": "initrd-cleanup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 414,
+                            "name": "initrd-parse-etc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 415,
+                            "name": "initrd-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 416,
+                            "name": "initrd-udevadm-cleanup-db",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 417,
+                            "name": "iprdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 418,
+                            "name": "iprinit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 419,
+                            "name": "iprupdate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 420,
+                            "name": "irqbalance",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 421,
+                            "name": "kdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 422,
+                            "name": "kmod-static-nodes",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 423,
+                            "name": "lvm2-lvmetad",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 424,
+                            "name": "lvm2-lvmpolld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 425,
+                            "name": "lvm2-monitor",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 426,
+                            "name": "lvm2-pvscan@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 427,
+                            "name": "microcode",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 428,
+                            "name": "plymouth-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 429,
+                            "name": "plymouth-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 430,
+                            "name": "plymouth-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 431,
+                            "name": "plymouth-quit-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 432,
+                            "name": "plymouth-quit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 433,
+                            "name": "plymouth-read-write",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 434,
+                            "name": "plymouth-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 435,
+                            "name": "plymouth-start",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 436,
+                            "name": "plymouth-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 437,
+                            "name": "polkit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 438,
+                            "name": "postfix",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 439,
+                            "name": "quotaon",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 440,
+                            "name": "rc-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 441,
+                            "name": "rdisc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 442,
+                            "name": "rdma-load-modules@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 443,
+                            "name": "rdma-ndd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 444,
+                            "name": "rdma",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 445,
+                            "name": "rescue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 446,
+                            "name": "rhel-autorelabel-mark",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 447,
+                            "name": "rhel-autorelabel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 448,
+                            "name": "rhel-configure",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 449,
+                            "name": "rhel-dmesg",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 450,
+                            "name": "rhel-domainname",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 451,
+                            "name": "rhel-import-state",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 452,
+                            "name": "rhel-loadmodules",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 453,
+                            "name": "rhel-readonly",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 454,
+                            "name": "rhsm-facts",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 455,
+                            "name": "rhsm",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 456,
+                            "name": "rhsmcertd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 457,
+                            "name": "rsyncd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 458,
+                            "name": "rsyncd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 459,
+                            "name": "rsyslog",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 460,
+                            "name": "selinux-policy-migrate-local-changes@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 461,
+                            "name": "serial-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 462,
+                            "name": "sshd-keygen",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 463,
+                            "name": "sshd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 464,
+                            "name": "sshd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 465,
+                            "name": "systemd-ask-password-console",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 466,
+                            "name": "systemd-ask-password-plymouth",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 467,
+                            "name": "systemd-ask-password-wall",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 468,
+                            "name": "systemd-backlight@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 469,
+                            "name": "systemd-binfmt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 470,
+                            "name": "systemd-bootchart",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 471,
+                            "name": "systemd-firstboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 472,
+                            "name": "systemd-fsck-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 473,
+                            "name": "systemd-fsck@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 474,
+                            "name": "systemd-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 475,
+                            "name": "systemd-hibernate-resume@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 476,
+                            "name": "systemd-hibernate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 477,
+                            "name": "systemd-hostnamed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 478,
+                            "name": "systemd-hwdb-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 479,
+                            "name": "systemd-hybrid-sleep",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 480,
+                            "name": "systemd-importd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 481,
+                            "name": "systemd-initctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 482,
+                            "name": "systemd-journal-catalog-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 483,
+                            "name": "systemd-journal-flush",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 484,
+                            "name": "systemd-journald",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 485,
+                            "name": "systemd-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 486,
+                            "name": "systemd-localed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 487,
+                            "name": "systemd-logind",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 488,
+                            "name": "systemd-machine-id-commit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 489,
+                            "name": "systemd-machined",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 490,
+                            "name": "systemd-modules-load",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 491,
+                            "name": "systemd-nspawn@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 492,
+                            "name": "systemd-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 493,
+                            "name": "systemd-quotacheck",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 494,
+                            "name": "systemd-random-seed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 495,
+                            "name": "systemd-readahead-collect",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 496,
+                            "name": "systemd-readahead-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 497,
+                            "name": "systemd-readahead-drop",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 498,
+                            "name": "systemd-readahead-replay",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 499,
+                            "name": "systemd-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 500,
+                            "name": "systemd-remount-fs",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 501,
+                            "name": "systemd-rfkill@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 502,
+                            "name": "systemd-shutdownd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 503,
+                            "name": "systemd-suspend",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 504,
+                            "name": "systemd-sysctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 505,
+                            "name": "systemd-timedated",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 506,
+                            "name": "systemd-tmpfiles-clean",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 507,
+                            "name": "systemd-tmpfiles-setup-dev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 508,
+                            "name": "systemd-tmpfiles-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 509,
+                            "name": "systemd-udev-settle",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 510,
+                            "name": "systemd-udev-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 511,
+                            "name": "systemd-udevd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 512,
+                            "name": "systemd-update-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 513,
+                            "name": "systemd-update-utmp-runlevel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 514,
+                            "name": "systemd-update-utmp",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 515,
+                            "name": "systemd-user-sessions",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 516,
+                            "name": "systemd-vconsole-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 517,
+                            "name": "tcsd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 518,
+                            "name": "teamd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 519,
+                            "name": "tuned",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 520,
+                            "name": "vgauthd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 521,
+                            "name": "vmtoolsd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 522,
+                            "name": "wpa_supplicant",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 523,
+                            "name": "glib-pacrunner",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 524,
+                            "name": "systemd-exit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 525,
+                            "name": "functions",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 526,
+                            "name": "netconsole",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 527,
+                            "name": "network",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 528,
+                            "name": "rhnsd",
+                            "typename": "linux_initprocess"
+                        }
+                    ]
+                },
+                {
+                    "id": 3,
+                    "name": "hana",
+                    "description": null,
+                    "type": "ManageIQ::Providers::Vmware::InfraManager::Vm",
+                    "uid_ems": "420ab880-a2e8-825e-3070-486a4414a3f0",
+                    "cpu_cores_per_socket": 1,
+                    "cpu_total_cores": 4,
+                    "disks_aligned": "True",
+                    "ems_ref": "vm-281",
+                    "has_rdm_disk": false,
+                    "host": {
+                        "ems_ref": "host-31"
+                    },
+                    "power_state": "on",
+                    "ram_size_in_bytes": 17179869184,
+                    "retired": null,
+                    "v_datastore_path": "NFS-Storage/hana/hana.vmx",
+                    "operating_system": {
+                        "product_type": "Linux",
+                        "product_name": "Red Hat Enterprise Linux Server release 7.6 (Maipo)",
+                        "distribution": "redhat"
+                    },
+                    "hardware": {
+                        "id": 7,
+                        "guest_os_full_name": "Red Hat Enterprise Linux 7 (64-bit)",
+                        "disks": [
+                            {
+                                "id": 26,
+                                "device_name": "disk",
+                                "device_type": "floppy",
+                                "disk_type": null,
+                                "filename": "[NFS-Storage] hana/",
+                                "free_space": null,
+                                "mode": null,
+                                "size": null,
+                                "size_on_disk": null
+                            },
+                            {
+                                "id": 4,
+                                "device_name": "Hard disk 1",
+                                "device_type": "disk",
+                                "disk_type": "thin",
+                                "filename": "[NFS-Storage] hana/hana.vmdk",
+                                "free_space": null,
+                                "mode": "persistent",
+                                "size": 42949672960,
+                                "size_on_disk": 17907970048
+                            }
+                        ],
+                        "nics": [
+                            {
+                                "id": 15,
+                                "device_name": "Network adapter 1",
+                                "device_type": "ethernet",
+                                "address": "00:50:56:8a:38:5c",
+                                "model": "VirtualVmxnet3",
+                                "uid_ems": "00:50:56:8a:38:5c",
+                                "network": {
+                                    "id": 20,
+                                    "ipaddress": "\"10.10.0.130\"",
+                                    "hostname": "hana"
+                                }
+                            }
+                        ]
+                    },
+                    "files": [
+                        {
+                            "id": 28,
+                            "name": "/etc/GeoIP.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 29,
+                            "name": "/etc/asound.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 30,
+                            "name": "/etc/autofs.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 31,
+                            "name": "/etc/autofs_ldap_auth.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 32,
+                            "name": "/etc/cgconfig.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 33,
+                            "name": "/etc/cgrules.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 34,
+                            "name": "/etc/cgsnapshot_blacklist.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 35,
+                            "name": "/etc/chrony.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 36,
+                            "name": "/etc/dracut.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 37,
+                            "name": "/etc/e2fsck.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 38,
+                            "name": "/etc/fprintd.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 39,
+                            "name": "/etc/fuse.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 40,
+                            "name": "/etc/host.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 41,
+                            "name": "/etc/idmapd.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 42,
+                            "name": "/etc/kdump.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 43,
+                            "name": "/etc/krb5.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 44,
+                            "name": "/etc/ld.so.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 45,
+                            "name": "/etc/libaudit.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 46,
+                            "name": "/etc/libuser.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 47,
+                            "name": "/etc/locale.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 48,
+                            "name": "/etc/logrotate.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 49,
+                            "name": "/etc/man_db.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 50,
+                            "name": "/etc/mke2fs.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 51,
+                            "name": "/etc/nfs.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 52,
+                            "name": "/etc/nfsmount.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 53,
+                            "name": "/etc/nsswitch.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 54,
+                            "name": "/etc/numad.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 55,
+                            "name": "/etc/pcp.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 56,
+                            "name": "/etc/request-key.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 57,
+                            "name": "/etc/resolv.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 58,
+                            "name": "/etc/rsyncd.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 59,
+                            "name": "/etc/rsyslog.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 60,
+                            "name": "/etc/sensors3.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 61,
+                            "name": "/etc/sestatus.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 62,
+                            "name": "/etc/sos.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 63,
+                            "name": "/etc/sudo-ldap.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 64,
+                            "name": "/etc/sudo.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 65,
+                            "name": "/etc/sysctl.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 66,
+                            "name": "/etc/tcsd.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 67,
+                            "name": "/etc/updatedb.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 68,
+                            "name": "/etc/usb_modeswitch.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 69,
+                            "name": "/etc/vconsole.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 70,
+                            "name": "/etc/yum.conf",
+                            "contents": null
+                        },
+                        {
+                            "id": 71,
+                            "name": "/etc/group",
+                            "contents": "root:x:0:\nbin:x:1:\ndaemon:x:2:\nsys:x:3:\nadm:x:4:\ntty:x:5:\ndisk:x:6:\nlp:x:7:\nmem:x:8:\nkmem:x:9:\nwheel:x:10:\ncdrom:x:11:\nmail:x:12:postfix\nman:x:15:\ndialout:x:18:\nfloppy:x:19:\ngames:x:20:\ntape:x:33:\nvideo:x:39:\nftp:x:50:\nlock:x:54:\naudio:x:63:\nnobody:x:99:\nusers:x:100:\nutmp:x:22:\nutempter:x:35:\ninput:x:999:\nsystemd-journal:x:190:\nsystemd-network:x:192:\ndbus:x:81:\npolkitd:x:998:\nssh_keys:x:997:\npostdrop:x:90:\npostfix:x:89:\nsshd:x:74:\nchrony:x:996:\npostgres:x:26:\nprintadmin:x:995:\nrpc:x:32:\ncgred:x:994:\nlibstoragemgmt:x:993:\ntss:x:59:\ngluster:x:992:\nabrt:x:173:\nrpcuser:x:29:\nnfsnobody:x:65534:\ntcpdump:x:72:\npcp:x:991:\nstapusr:x:156:\nstapsys:x:157:\nstapdev:x:158:\nntp:x:38:\nslocate:x:21:\noprofile:x:16:\nsapsys:x:79:\nhxeshm:x:1000:hxeadm\n"
+                        },
+                        {
+                            "id": 72,
+                            "name": "/etc/hosts",
+                            "contents": null
+                        },
+                        {
+                            "id": 73,
+                            "name": "/usr/sap/hostctrl/exe/saphostctrl",
+                            "contents": null
+                        }
+                    ],
+                    "system_services": [
+                        {
+                            "id": 169,
+                            "name": "NetworkManager-dispatcher",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 170,
+                            "name": "NetworkManager-wait-online",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 171,
+                            "name": "NetworkManager",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 172,
+                            "name": "abrt-ccpp",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 173,
+                            "name": "abrt-oops",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 174,
+                            "name": "abrt-pstoreoops",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 175,
+                            "name": "abrt-vmcore",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 176,
+                            "name": "abrt-xorg",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 177,
+                            "name": "abrtd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 178,
+                            "name": "arp-ethers",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 179,
+                            "name": "atd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 180,
+                            "name": "auditd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 181,
+                            "name": "auth-rpcgss-module",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 182,
+                            "name": "autofs",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 183,
+                            "name": "blk-availability",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 184,
+                            "name": "brandbot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 185,
+                            "name": "canberra-system-bootup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 186,
+                            "name": "canberra-system-shutdown-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 187,
+                            "name": "canberra-system-shutdown",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 188,
+                            "name": "cgconfig",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 189,
+                            "name": "cgdcbxd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 190,
+                            "name": "cgred",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 191,
+                            "name": "chrony-dnssrv@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 192,
+                            "name": "chrony-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 193,
+                            "name": "chronyd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 194,
+                            "name": "console-getty",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 195,
+                            "name": "console-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 196,
+                            "name": "container-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 197,
+                            "name": "cpupower",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 198,
+                            "name": "crond",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 199,
+                            "name": "dbus",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 200,
+                            "name": "debug-shell",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 201,
+                            "name": "dm-event",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 202,
+                            "name": "dmraid-activation",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 203,
+                            "name": "dracut-cmdline",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 204,
+                            "name": "dracut-initqueue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 205,
+                            "name": "dracut-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 206,
+                            "name": "dracut-pre-mount",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 207,
+                            "name": "dracut-pre-pivot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 208,
+                            "name": "dracut-pre-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 209,
+                            "name": "dracut-pre-udev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 210,
+                            "name": "dracut-shutdown",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 211,
+                            "name": "ebtables",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 212,
+                            "name": "emergency",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 213,
+                            "name": "fancontrol",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 214,
+                            "name": "fcoe",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 215,
+                            "name": "firewalld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 216,
+                            "name": "fprintd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 217,
+                            "name": "fstrim",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 218,
+                            "name": "getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 219,
+                            "name": "gssproxy",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 220,
+                            "name": "halt-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 221,
+                            "name": "hwloc-dump-hwdata",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 222,
+                            "name": "initrd-cleanup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 223,
+                            "name": "initrd-parse-etc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 224,
+                            "name": "initrd-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 225,
+                            "name": "initrd-udevadm-cleanup-db",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 226,
+                            "name": "iprdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 227,
+                            "name": "iprinit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 228,
+                            "name": "iprupdate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 229,
+                            "name": "irqbalance",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 230,
+                            "name": "iscsi-shutdown",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 231,
+                            "name": "iscsi",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 232,
+                            "name": "iscsid",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 233,
+                            "name": "iscsiuio",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 234,
+                            "name": "kdump",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 235,
+                            "name": "kmod-static-nodes",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 236,
+                            "name": "kpatch",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 237,
+                            "name": "libstoragemgmt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 238,
+                            "name": "lldpad",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 239,
+                            "name": "lm_sensors",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 240,
+                            "name": "lvm2-lvmetad",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 241,
+                            "name": "lvm2-lvmpolld",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 242,
+                            "name": "lvm2-monitor",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 243,
+                            "name": "lvm2-pvscan@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 244,
+                            "name": "mdadm-grow-continue@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 245,
+                            "name": "mdadm-last-resort@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 246,
+                            "name": "mdmon@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 247,
+                            "name": "mdmonitor",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 248,
+                            "name": "microcode",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 249,
+                            "name": "multipathd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 250,
+                            "name": "nfs-blkmap",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 251,
+                            "name": "nfs-config",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 252,
+                            "name": "nfs-idmapd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 253,
+                            "name": "nfs-mountd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 254,
+                            "name": "nfs-server",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 255,
+                            "name": "nfs-utils",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 256,
+                            "name": "ntpdate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 257,
+                            "name": "numad",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 258,
+                            "name": "plymouth-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 259,
+                            "name": "plymouth-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 260,
+                            "name": "plymouth-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 261,
+                            "name": "plymouth-quit-wait",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 262,
+                            "name": "plymouth-quit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 263,
+                            "name": "plymouth-read-write",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 264,
+                            "name": "plymouth-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 265,
+                            "name": "plymouth-start",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 266,
+                            "name": "plymouth-switch-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 267,
+                            "name": "pmcd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 268,
+                            "name": "pmie",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 269,
+                            "name": "pmlogger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 270,
+                            "name": "pmproxy",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 271,
+                            "name": "polkit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 272,
+                            "name": "postfix",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 273,
+                            "name": "powertop",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 274,
+                            "name": "psacct",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 275,
+                            "name": "qemu-guest-agent",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 276,
+                            "name": "quotaon",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 277,
+                            "name": "rc-local",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 278,
+                            "name": "rdisc",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 279,
+                            "name": "rescue",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 280,
+                            "name": "rhel-autorelabel-mark",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 281,
+                            "name": "rhel-autorelabel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 282,
+                            "name": "rhel-configure",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 283,
+                            "name": "rhel-dmesg",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 284,
+                            "name": "rhel-domainname",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 285,
+                            "name": "rhel-import-state",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 286,
+                            "name": "rhel-loadmodules",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 287,
+                            "name": "rhel-readonly",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 288,
+                            "name": "rhsm-facts",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 289,
+                            "name": "rhsm",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 290,
+                            "name": "rhsmcertd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 291,
+                            "name": "rngd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 292,
+                            "name": "rpc-gssd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 293,
+                            "name": "rpc-rquotad",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 294,
+                            "name": "rpc-statd-notify",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 295,
+                            "name": "rpc-statd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 296,
+                            "name": "rpcbind",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 297,
+                            "name": "rsyncd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 298,
+                            "name": "rsyncd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 299,
+                            "name": "rsyslog",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 300,
+                            "name": "selinux-policy-migrate-local-changes@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 301,
+                            "name": "serial-getty@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 302,
+                            "name": "smartd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 303,
+                            "name": "sshd-keygen",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 304,
+                            "name": "sshd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 305,
+                            "name": "sshd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 306,
+                            "name": "sysstat",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 307,
+                            "name": "systemd-ask-password-console",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 308,
+                            "name": "systemd-ask-password-plymouth",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 309,
+                            "name": "systemd-ask-password-wall",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 310,
+                            "name": "systemd-backlight@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 311,
+                            "name": "systemd-binfmt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 312,
+                            "name": "systemd-bootchart",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 313,
+                            "name": "systemd-firstboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 314,
+                            "name": "systemd-fsck-root",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 315,
+                            "name": "systemd-fsck@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 316,
+                            "name": "systemd-halt",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 317,
+                            "name": "systemd-hibernate-resume@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 318,
+                            "name": "systemd-hibernate",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 319,
+                            "name": "systemd-hostnamed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 320,
+                            "name": "systemd-hwdb-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 321,
+                            "name": "systemd-hybrid-sleep",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 322,
+                            "name": "systemd-importd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 323,
+                            "name": "systemd-initctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 324,
+                            "name": "systemd-journal-catalog-update",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 325,
+                            "name": "systemd-journal-flush",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 326,
+                            "name": "systemd-journald",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 327,
+                            "name": "systemd-kexec",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 328,
+                            "name": "systemd-localed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 329,
+                            "name": "systemd-logind",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 330,
+                            "name": "systemd-machine-id-commit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 331,
+                            "name": "systemd-machined",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 332,
+                            "name": "systemd-modules-load",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 333,
+                            "name": "systemd-nspawn@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 334,
+                            "name": "systemd-poweroff",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 335,
+                            "name": "systemd-quotacheck",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 336,
+                            "name": "systemd-random-seed",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 337,
+                            "name": "systemd-readahead-collect",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 338,
+                            "name": "systemd-readahead-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 339,
+                            "name": "systemd-readahead-drop",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 340,
+                            "name": "systemd-readahead-replay",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 341,
+                            "name": "systemd-reboot",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 342,
+                            "name": "systemd-remount-fs",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 343,
+                            "name": "systemd-rfkill@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 344,
+                            "name": "systemd-shutdownd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 345,
+                            "name": "systemd-suspend",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 346,
+                            "name": "systemd-sysctl",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 347,
+                            "name": "systemd-timedated",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 348,
+                            "name": "systemd-tmpfiles-clean",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 349,
+                            "name": "systemd-tmpfiles-setup-dev",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 350,
+                            "name": "systemd-tmpfiles-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 351,
+                            "name": "systemd-udev-settle",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 352,
+                            "name": "systemd-udev-trigger",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 353,
+                            "name": "systemd-udevd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 354,
+                            "name": "systemd-update-done",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 355,
+                            "name": "systemd-update-utmp-runlevel",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 356,
+                            "name": "systemd-update-utmp",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 357,
+                            "name": "systemd-user-sessions",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 358,
+                            "name": "systemd-vconsole-setup",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 359,
+                            "name": "target",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 360,
+                            "name": "tcsd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 361,
+                            "name": "teamd@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 362,
+                            "name": "tuned",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 363,
+                            "name": "usb_modeswitch@",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 364,
+                            "name": "vdo",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 365,
+                            "name": "vgauthd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 366,
+                            "name": "vmtoolsd",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 367,
+                            "name": "wpa_supplicant",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 368,
+                            "name": "at-spi-dbus-bus",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 369,
+                            "name": "glib-pacrunner",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 370,
+                            "name": "systemd-exit",
+                            "typename": "linux_systemd"
+                        },
+                        {
+                            "id": 371,
+                            "name": "boot.local",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 372,
+                            "name": "functions",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 373,
+                            "name": "netconsole",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 374,
+                            "name": "network",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 375,
+                            "name": "rhnsd",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 376,
+                            "name": "sapinit",
+                            "typename": "linux_initprocess"
+                        },
+                        {
+                            "id": 377,
+                            "name": "sapinit.old",
+                            "typename": "linux_initprocess"
+                        }
+                    ]
+                }
+            ],
+            "ems_extensions": [
+                {
+                    "id": 1,
+                    "ems_ref": "com.vmware.vim.sms",
+                    "key": "com.vmware.vim.sms",
+                    "company": "VMware Inc.",
+                    "label": "VMware vCenter Storage Monitoring Service",
+                    "summary": "Storage Monitoring and Reporting",
+                    "version": "6.7.0"
+                },
+                {
+                    "id": 2,
+                    "ems_ref": "com.vmware.vim.vsm",
+                    "key": "com.vmware.vim.vsm",
+                    "company": "VMware Inc.",
+                    "label": "vService Manager",
+                    "summary": "The vService Manager manages vService dependencies on virtual machines and vApps, and vServices provided by vCenter extensions",
+                    "version": "6.7.0"
+                },
+                {
+                    "id": 3,
+                    "ems_ref": "VirtualCenter",
+                    "key": "VirtualCenter",
+                    "company": null,
+                    "label": "VirtualCenter dynamic events and tasks",
+                    "summary": "Extension for declaring dynamic events, tasks and faults from within the VirtualCenter server",
+                    "version": "6.7.0"
+                },
+                {
+                    "id": 4,
+                    "ems_ref": "com.vmware.vim.stats.report",
+                    "key": "com.vmware.vim.stats.report",
+                    "company": null,
+                    "label": "Performance charts built-in extension",
+                    "summary": "Performance charts built-in extension",
+                    "version": "6.7.0"
+                },
+                {
+                    "id": 5,
+                    "ems_ref": "com.vmware.vim.sps",
+                    "key": "com.vmware.vim.sps",
+                    "company": "VMware Inc.",
+                    "label": "VMware vSphere Profile-driven Storage Service",
+                    "summary": "Profile-driven Storage Placement and Compliance Management",
+                    "version": "6.7.0"
+                },
+                {
+                    "id": 6,
+                    "ems_ref": "com.vmware.vim.vcha",
+                    "key": "com.vmware.vim.vcha",
+                    "company": null,
+                    "label": "description",
+                    "summary": "High availability solution for vCenter Server Appliance",
+                    "version": "6.7.0"
+                },
+                {
+                    "id": 7,
+                    "ems_ref": "hostdiag",
+                    "key": "hostdiag",
+                    "company": null,
+                    "label": "description",
+                    "summary": "Internal extension to declare diagnostic events from VMware Host systems.",
+                    "version": "6.7.0"
+                },
+                {
+                    "id": 8,
+                    "ems_ref": "com.vmware.vim.ls",
+                    "key": "com.vmware.vim.ls",
+                    "company": "VMware, Inc.",
+                    "label": "License Services",
+                    "summary": "Provides various license services",
+                    "version": "6.7.0"
+                },
+                {
+                    "id": 9,
+                    "ems_ref": "com.vmware.vsan.health",
+                    "key": "com.vmware.vsan.health",
+                    "company": null,
+                    "label": "VMware vSAN Health Service",
+                    "summary": "",
+                    "version": "1.0.0"
+                },
+                {
+                    "id": 10,
+                    "ems_ref": "com.vmware.vcIntegrity",
+                    "key": "com.vmware.vcIntegrity",
+                    "company": null,
+                    "label": "VMware vSphere Update Manager Extension",
+                    "summary": "VMware vSphere Update Manager extension",
+                    "version": "6.7.0.41422"
+                },
+                {
+                    "id": 11,
+                    "ems_ref": "com.vmware.vim.eam",
+                    "key": "com.vmware.vim.eam",
+                    "company": "VMware Inc.",
+                    "label": "vSphere ESX Agent Manager",
+                    "summary": "Manages the life-cycle of agent VIBs and VMs",
+                    "version": "6.7.0"
+                },
+                {
+                    "id": 12,
+                    "ems_ref": "com.vmware.vcenter.vmtx",
+                    "key": "com.vmware.vcenter.vmtx",
+                    "company": null,
+                    "label": "vSphere Content Library",
+                    "summary": "vSphere Content Library",
+                    "version": "6.6"
+                },
+                {
+                    "id": 13,
+                    "ems_ref": "com.vmware.vcenter.iso",
+                    "key": "com.vmware.vcenter.iso",
+                    "company": null,
+                    "label": "vSphere ISO Service",
+                    "summary": "vSphere ISO Service",
+                    "version": "6.0"
+                },
+                {
+                    "id": 14,
+                    "ems_ref": "com.vmware.vsphere.client",
+                    "key": "com.vmware.vsphere.client",
+                    "company": "VMware, Inc.",
+                    "label": "vSphere Client",
+                    "summary": "vSphere Client Extension",
+                    "version": "1.0.0"
+                },
+                {
+                    "id": 15,
+                    "ems_ref": "com.vmware.vmcam",
+                    "key": "com.vmware.vmcam",
+                    "company": "VMware, Inc.",
+                    "label": "vSphere Authentication Proxy",
+                    "summary": "Support joining ESXi server to Active Directory Domain",
+                    "version": "6.0"
+                },
+                {
+                    "id": 16,
+                    "ems_ref": "com.vmware.vsan.dp",
+                    "key": "com.vmware.vsan.dp",
+                    "company": "VMware, Inc.",
+                    "label": "VMware vCenter VSAN Data Protection Service",
+                    "summary": "VMware vCenter VSAN Data Protection Service",
+                    "version": "1.0"
+                },
+                {
+                    "id": 17,
+                    "ems_ref": "com.vmware.ovf",
+                    "key": "com.vmware.ovf",
+                    "company": null,
+                    "label": "Open Virtualization Format Service",
+                    "summary": "Open Virtualization Format Service",
+                    "version": "6.0"
+                },
+                {
+                    "id": 18,
+                    "ems_ref": "com.vmware.cl",
+                    "key": "com.vmware.cl",
+                    "company": null,
+                    "label": "vSphere Content Library Service",
+                    "summary": "vSphere Content Library Service",
+                    "version": "6.0"
+                },
+                {
+                    "id": 19,
+                    "ems_ref": "com.vmware.rbd",
+                    "key": "com.vmware.rbd",
+                    "company": "VMware, Inc.",
+                    "label": "RuleEngine",
+                    "summary": "Rule-Based Deployment",
+                    "version": "6.7.0.00000"
+                },
+                {
+                    "id": 20,
+                    "ems_ref": "com.vmware.vsphere.client.h5vsan",
+                    "key": "com.vmware.vsphere.client.h5vsan",
+                    "company": null,
+                    "label": "VMware vSAN H5 extension",
+                    "summary": "VMware vSAN H5 extension",
+                    "version": "1.0.0"
+                },
+                {
+                    "id": 21,
+                    "ems_ref": "com.vmware.vrops.install",
+                    "key": "com.vmware.vrops.install",
+                    "company": null,
+                    "label": "VMware vRops extension",
+                    "summary": "VMware vRops extension",
+                    "version": "1.0.0"
+                }
+            ],
+            "ems_licenses": [
+                {
+                    "id": 1,
+                    "ems_ref": "00000-00000-00000-00000-00000",
+                    "name": "Product Evaluation",
+                    "license_edition": "eval",
+                    "total_licenses": 0,
+                    "used_licenses": null
+                },
+                {
+                    "id": 2,
+                    "ems_ref": "4003N-0XH04-58K85-0EC0K-1NVH1",
+                    "name": "VMware vSphere 6 Enterprise",
+                    "license_edition": "esx.enterprise.cpuPackage",
+                    "total_licenses": 10,
+                    "used_licenses": 8
+                },
+                {
+                    "id": 3,
+                    "ems_ref": "0J28J-0CJ00-18C9C-0RCAM-082MN",
+                    "name": "VMware vCenter Server 6 Standard",
+                    "license_edition": "vc.standard.instance",
+                    "total_licenses": 1,
+                    "used_licenses": 1
+                }
+            ],
+            "ems_clusters": [
+                {
+                    "id": 2,
+                    "name": "VMCluster",
+                    "uid_ems": "domain-c26",
+                    "ems_ref": "domain-c26",
+                    "ha_enabled": false,
+                    "drs_enabled": true,
+                    "effective_cpu": 13080,
+                    "effective_memory": 35436625920,
+                    "v_parent_datacenter" : "JON TEST DC"
+                }
+            ],
+            "hosts": [
+                {
+                    "id": 4,
+                    "name": "esx2.example.com",
+                    "type": "ManageIQ::Providers::Vmware::InfraManager::HostEsx",
+                    "hostname": "esx2.example.com",
+                    "ipaddress": "192.168.0.52",
+                    "power_state": "on",
+                    "guid": "b4002278-418f-4a2b-bef1-6070f896153b",
+                    "uid_ems": "esx2.example.com",
+                    "ems_ref": "host-31",
+                    "mac_address": "",
+                    "maintenance": false,
+                    "vmm_vendor": "vmware",
+                    "vmm_version": "6.7.0",
+                    "vmm_product": "ESXi",
+                    "vmm_buildnumber": "10302608",
+                    "archived": false,
+                    "cpu_cores_per_socket": 1,
+                    "cpu_total_cores": 4,
+                    "ems_cluster": {
+                        "COMMENT": "Host without cluster",
+                        "ems_ref": "__domain-c26"
+                    },
+                    "hardware": {
+                        "memory_mb": 20479
+                    }
+                },
+                {
+                    "id": 3,
+                    "name": "esx1.example.com",
+                    "type": "ManageIQ::Providers::Vmware::InfraManager::HostEsx",
+                    "hostname": "esx1.example.com",
+                    "ipaddress": "192.168.0.51",
+                    "power_state": "on",
+                    "guid": "f1771291-6712-48c4-a1bd-16969994122e",
+                    "uid_ems": "esx1.example.com",
+                    "ems_ref": "host-47",
+                    "mac_address": "",
+                    "maintenance": false,
+                    "vmm_vendor": "vmware",
+                    "vmm_version": "6.7.0",
+                    "vmm_product": "ESXi",
+                    "vmm_buildnumber": "10302608",
+                    "archived": false,
+                    "cpu_cores_per_socket": 0,
+                    "cpu_total_cores": 4,
+                    "ems_cluster": {
+                        "ems_ref": "domain-c26"
+                    },
+                    "hardware": {
+                        "memory_mb": 20479
+                    }
+                }
+            ],
+            "storages": [
+                {
+                    "id": 4,
+                    "name": "NFS-Storage",
+                    "location": "e2ed7391-82a03340",
+                    "store_type": "NFS",
+                    "total_space": 214736809984,
+                    "free_space": 71829426176,
+                    "uncommitted": 89664106496,
+                    "storage_domain_type": null,
+                    "host_storages": [
+                        {
+                            "ems_ref": "datastore-221",
+                            "host": {
+                                "ems_ref": "host-47"
+                            }
+                        },
+                        {
+                            "ems_ref": "datastore-221",
+                            "host": {
+                                "ems_ref": "host-31"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-327

In order to avoid VMs to be removed from the report if the cores_per_socket is 0 , it's been added a new code that in that case it will assign 0 to the model.cpuCores