### PR TITLE
MIGENG-324: MA - Prototype RBAC - Remove IS_ORG_ADMIN header and checks

### DIFF
--- a/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
@@ -45,19 +45,12 @@ public class RBACRouteBuilder extends RouteBuilder {
                         .to("direct:request-forbidden")
                 .end()
 
-                .choice()
-                    .when(exchange -> exchange.getIn().getHeader(RouteBuilderExceptionHandler.X_RH_IDENTITY_IS_ORG_ADMIN, Boolean.class))
-                        .setHeader(RBAC_USER_PERMISSIONS, constant(Collections.singletonList(UserPermission.WILDCARD_PERMISSION)))
-                    .endChoice()
-                    .otherwise()
-                        .enrich("direct:fetch-rbac-user-access", (oldExchange, newExchange) -> {
-                            List<Acl> acls = newExchange.getIn().getBody(List.class);
-                            List<UserPermission> userPermissions = RBACUtils.generateUserPermissions(acls);
-                            oldExchange.getIn().setHeader(RBAC_USER_PERMISSIONS, userPermissions);
-                            return oldExchange;
-                        })
-                    .endChoice()
-                .end();
+                .enrich("direct:fetch-rbac-user-access", (oldExchange, newExchange) -> {
+                    List<Acl> acls = newExchange.getIn().getBody(List.class);
+                    List<UserPermission> userPermissions = RBACUtils.generateUserPermissions(acls);
+                    oldExchange.getIn().setHeader(RBAC_USER_PERMISSIONS, userPermissions);
+                    return oldExchange;
+                });
 
         from("direct:fetch-rbac-user-access")
                 .routeId("fetch-rbac-user-access")

--- a/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
@@ -84,11 +84,9 @@ public class MainRouteBuilder extends RouteBuilderExceptionHandler {
             JsonNode xRhIdentityJsonNode = new ObjectMapper().reader().readTree(xRhIdentityDecoded);
 
             String username = Utils.getFieldValueFromJsonNode(xRhIdentityJsonNode, "identity", "user", "username").textValue();
-            Boolean isOrgAdmin = Utils.getFieldValueFromJsonNode(xRhIdentityJsonNode, "identity", "user", "is_org_admin").booleanValue();
 
             exchange.getIn().setHeader(USERNAME, username);
             exchange.getIn().setHeader(X_RH_IDENTITY_JSON_NODE, xRhIdentityJsonNode);
-            exchange.getIn().setHeader(X_RH_IDENTITY_IS_ORG_ADMIN, isOrgAdmin);
         }
     };
 

--- a/src/main/java/org/jboss/xavier/integrations/route/RouteBuilderExceptionHandler.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/RouteBuilderExceptionHandler.java
@@ -21,7 +21,6 @@ public abstract class RouteBuilderExceptionHandler extends RouteBuilder {
 
     public static final String X_RH_IDENTITY = "x-rh-identity";
     public static final String X_RH_IDENTITY_JSON_NODE = "x-rh-identity-json-node";
-    public static final String X_RH_IDENTITY_IS_ORG_ADMIN = "x-rh-identity-is-org-admin";
 
     @Inject
     protected AnalysisService analysisService;

--- a/src/test/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder_DirectFetchRbacAndProcessDataTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder_DirectFetchRbacAndProcessDataTest.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.AdviceWithRouteBuilder;
 import org.jboss.xavier.Application;
-import org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler;
 import org.jboss.xavier.integrations.route.XavierCamelTest;
 import org.jboss.xavier.integrations.util.TestUtil;
 import org.junit.Before;
@@ -135,9 +134,6 @@ public class RBACRouteBuilder_DirectFetchRbacAndProcessDataTest extends XavierCa
                 .createProducerTemplate()
                 .request("direct:fetch-and-process-rbac-user-access", exchange1 -> {
                     exchange1.getIn().setHeader(TestUtil.HEADER_RH_IDENTITY, TestUtil.getBase64RHIdentity());
-
-                    // Set manually this header since it comes from the Rest filters
-                    exchange1.getIn().setHeader(RouteBuilderExceptionHandler.X_RH_IDENTITY_IS_ORG_ADMIN, false);
                 });
 
         //Then
@@ -184,9 +180,6 @@ public class RBACRouteBuilder_DirectFetchRbacAndProcessDataTest extends XavierCa
                 .createProducerTemplate()
                 .request("direct:fetch-and-process-rbac-user-access", exchange1 -> {
                     exchange1.getIn().setHeader(TestUtil.HEADER_RH_IDENTITY, TestUtil.getBase64RHIdentity());
-
-                    // Set manually this header since it comes from the Rest filters
-                    exchange1.getIn().setHeader(RouteBuilderExceptionHandler.X_RH_IDENTITY_IS_ORG_ADMIN, false);
                 });
 
         //Then


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-324

- Remove `is_org_admin` header and checks from the RBAC components. Every single user should be treated like any common user. 