### PR TITLE
MIGENG-504: Unable to download report via api url

### DIFF
--- a/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
@@ -61,7 +61,7 @@ public class RBACRouteBuilder extends RouteBuilder {
                 .loopDoWhile(exchange -> exchange.getIn().getHeader(RBAC_NEXT_LINK) != null)
                     .setHeader(Exchange.HTTP_METHOD, constant(HttpMethods.GET))
                     .setHeader(Exchange.CONTENT_TYPE, constant(ContentType.APPLICATION_JSON.getMimeType())) // Content-type is a way to specify the media type of request being sent from the client to the server (valid on POST and PUT)
-                    .setHeader(HttpHeaders.ACCEPT).constant(ContentType.APPLICATION_JSON.getMimeType()) // Accept header is a way for a client to specify the media type of the response content it is expecting.
+                    .setHeader(HttpHeaders.ACCEPT, constant(ContentType.APPLICATION_JSON.getMimeType())) // Accept header is a way for a client to specify the media type of the response content it is expecting.
                     .setHeader(Exchange.HTTP_PATH, constant(rbacPath))
                     .process(exchange -> {
                         String httpQuery;

--- a/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
@@ -81,7 +81,6 @@ public class RBACRouteBuilder extends RouteBuilder {
                             .setHeader(RBAC_NEXT_LINK, () -> null)
                         .otherwise()
                             .convertBodyTo(String.class)
-                            .log("RBAC Response= ${body}")
                             .process(exchange -> {
                                 String body = exchange.getIn().getBody(String.class);
                                 RbacResponse rbacResponse = new ObjectMapper().readValue(body, RbacResponse.class);

--- a/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
@@ -60,6 +60,7 @@ public class RBACRouteBuilder extends RouteBuilder {
                     .setHeader(Exchange.HTTP_METHOD, constant(HttpMethods.GET))
                     .setHeader(Exchange.CONTENT_TYPE, constant("application/json"))
                     .setHeader(Exchange.HTTP_PATH, constant(rbacPath))
+                    .setHeader("Accept").simple("application/json") // Force RBAC to response in JSON
                     .process(exchange -> {
                         String httpQuery;
                         String nextLink = exchange.getIn().getHeader(RBAC_NEXT_LINK, String.class);

--- a/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
@@ -80,6 +80,7 @@ public class RBACRouteBuilder extends RouteBuilder {
                             .setHeader(RBAC_NEXT_LINK, () -> null)
                         .otherwise()
                             .convertBodyTo(String.class)
+                            .log("RBAC Response= ${body}")
                             .process(exchange -> {
                                 String body = exchange.getIn().getBody(String.class);
                                 RbacResponse rbacResponse = new ObjectMapper().readValue(body, RbacResponse.class);

--- a/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.http4.HttpMethods;
+import org.apache.http.HttpHeaders;
+import org.apache.http.entity.ContentType;
 import org.jboss.xavier.integrations.route.RouteBuilderExceptionHandler;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -58,8 +60,8 @@ public class RBACRouteBuilder extends RouteBuilder {
                 .setHeader(RBAC_NEXT_LINK, constant(""))
                 .loopDoWhile(exchange -> exchange.getIn().getHeader(RBAC_NEXT_LINK) != null)
                     .setHeader(Exchange.HTTP_METHOD, constant(HttpMethods.GET))
-                    .setHeader(Exchange.CONTENT_TYPE, constant("application/json")) // Content-type is a way to specify the media type of request being sent from the client to the server (valid on POST and PUT)
-                    .setHeader("Accept").simple("application/json") // Accept header is a way for a client to specify the media type of the response content it is expecting.
+                    .setHeader(Exchange.CONTENT_TYPE, constant(ContentType.APPLICATION_JSON.getMimeType())) // Content-type is a way to specify the media type of request being sent from the client to the server (valid on POST and PUT)
+                    .setHeader(HttpHeaders.ACCEPT).constant(ContentType.APPLICATION_JSON.getMimeType()) // Accept header is a way for a client to specify the media type of the response content it is expecting.
                     .setHeader(Exchange.HTTP_PATH, constant(rbacPath))
                     .process(exchange -> {
                         String httpQuery;

--- a/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/rbac/RBACRouteBuilder.java
@@ -58,9 +58,9 @@ public class RBACRouteBuilder extends RouteBuilder {
                 .setHeader(RBAC_NEXT_LINK, constant(""))
                 .loopDoWhile(exchange -> exchange.getIn().getHeader(RBAC_NEXT_LINK) != null)
                     .setHeader(Exchange.HTTP_METHOD, constant(HttpMethods.GET))
-                    .setHeader(Exchange.CONTENT_TYPE, constant("application/json"))
+                    .setHeader(Exchange.CONTENT_TYPE, constant("application/json")) // Content-type is a way to specify the media type of request being sent from the client to the server (valid on POST and PUT)
+                    .setHeader("Accept").simple("application/json") // Accept header is a way for a client to specify the media type of the response content it is expecting.
                     .setHeader(Exchange.HTTP_PATH, constant(rbacPath))
-                    .setHeader("Accept").simple("application/json") // Force RBAC to response in JSON
                     .process(exchange -> {
                         String httpQuery;
                         String nextLink = exchange.getIn().getHeader(RBAC_NEXT_LINK, String.class);

--- a/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
@@ -321,7 +321,7 @@ public class MainRouteBuilder extends RouteBuilderExceptionHandler {
     private Processor httpError400() {
         return exchange -> {
           exchange.getIn().setBody("{ \"error\": \"Bad Request\"}");
-          exchange.getIn().setHeader(Exchange.CONTENT_TYPE, "application/json");
+          exchange.getIn().setHeader(Exchange.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
           exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, 400);
         };
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/MIGENG-504

Adding the "Accept Header" for fetching data from the RBAC Server.

- An error occurred when accessing the API thought the browser.
- The Reason of the error is that the Apache Camel Route is not specifying the "Accept" Http Header, therefore the route is using the came "Accept" Http Header that comes from the browser.

Notes:
- `Content-type` is a way to specify the media type of request being sent from the client to the server (valid on POST and PUT)
- `Accept` header is a way for a client to specify the media type of the response content it is expecting.