### PR TITLE
[RFR] Add Jenkins smoke groovy file

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -13,7 +13,7 @@ if (env.CHANGE_ID) {
         ocDeployerComponentPath: "xavier/xavier-integration",
     
         // the service sets to deploy into the test environment
-        ocDeployerServiceSets: "xavier/xavier-integration",
+        ocDeployerServiceSets: "platform-mq,rbac,ingress,xavier",
     
         // the iqe plugins to install for the test
         iqePlugins: ["iqe-migration-analytics-plugin"],

--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -1,0 +1,27 @@
+/*
+* Requires: https://github.com/RedHatInsights/insights-pipeline-lib
+*/
+
+@Library("github.com/RedHatInsights/insights-pipeline-lib@v3") _
+
+if (env.CHANGE_ID) {
+    execSmokeTest(
+        // the service-set/component for this app in e2e-deploy "buildfactory"
+        ocDeployerBuilderPath: "xavier/xavier-integration",
+    
+        // the service-set/component for this app in e2e-deploy "templates"
+        ocDeployerComponentPath: "xavier/xavier-integration",
+    
+        // the service sets to deploy into the test environment
+        ocDeployerServiceSets: "xavier/xavier-integration",
+    
+        // the iqe plugins to install for the test
+        iqePlugins: ["iqe-migration-analytics-plugin"],
+    
+        // the pytest marker to use when calling `iqe tests all`
+        pytestMarker: "ma_smoke",
+    
+        // optional id for an IQE configuration file stored as a secret in Jenkins
+        //configFileCredentialsId: "myId",
+    )
+}


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

- I followed this doc - https://github.com/RedHatInsights/iqe-jenkins/tree/master/smoke
- I wanted to know if I need to add ```Jenkinsfile-smoke.groovy``` file in [this repo](https://github.com/project-xavier/xavier-analytics) too. As I can see [buildfactory](https://github.com/RedHatInsights/e2e-deploy/tree/master/buildfactory/xavier) and [template](https://github.com/RedHatInsights/e2e-deploy/tree/master/templates/xavier) for both **xavier-analytics** and **xavier-integration**.
- Also, wanted to make sure that smoke [configuration in IQE Plugin](https://gitlab.cee.redhat.com/insights-qe/iqe-migration-analytics-plugin/-/merge_requests/30) is right?
- Created PR for jenkins smoke build - https://github.com/RedHatInsights/iqe-jenkins/pull/31
- @mrizzi can you help me with understanding this ID - ```env.CHANGE_ID```. I refered other plugins and added but didn't get clear idea behind it.