### PR TITLE
[RFR] Fix iqe plugin name

### DIFF
--- a/Jenkinsfile-smoke.groovy
+++ b/Jenkinsfile-smoke.groovy
@@ -16,7 +16,7 @@ if (env.CHANGE_ID) {
         ocDeployerServiceSets: "platform-mq,rbac,ingress,xavier",
     
         // the iqe plugins to install for the test
-        iqePlugins: ["iqe-migration-analytics-plugin"],
+        iqePlugins: ["iqe-migration_analytics-plugin"],
     
         // the pytest marker to use when calling `iqe tests all`
         pytestMarker: "ma_smoke",


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

- Plugin name should match package name - https://gitlab.cee.redhat.com/insights-qe/iqe-migration-analytics-plugin/-/blob/master/iqe_migration_analytics/__init__.py#L28