### PR TITLE
(stable) MIGENG-449 added the delete action of the S3 file and the test in End…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
         - LOGGING_LEVEL_ROOT=info
         - ANALYSIS_DATAINTEGRITY_LOG=false
       script:
-        - mvn test -Pcoverage
+        - mvn test -Pcoverage -Danalysis.dataintegrity.log=false
         - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then sonar-scanner; fi'
         - bash <(curl -s https://codecov.io/bash)
 

--- a/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
+++ b/src/main/java/org/jboss/xavier/integrations/route/MainRouteBuilder.java
@@ -229,13 +229,13 @@ public class MainRouteBuilder extends RouteBuilderExceptionHandler {
                         })
                     .endChoice()
                     .otherwise()
-                        .setHeader("CamelAwsS3Key", simple("${header.AnalysisPayloadStorageId}"))
-                        .setHeader("CamelAwsS3DownloadLinkExpiration", constant(s3DownloadLinkExpiration))
-                        .setHeader("CamelAwsS3Operation", constant("downloadLink"))
+                        .setHeader(S3Constants.KEY, simple("${header.AnalysisPayloadStorageId}"))
+                        .setHeader(S3Constants.DOWNLOAD_LINK_EXPIRATION, constant(s3DownloadLinkExpiration))
+                        .setHeader(S3Constants.S3_OPERATION, constant("downloadLink"))
                         .to("aws-s3:{{S3_BUCKET}}?amazonS3Client=#s3client").id("aws-s3-get-download-link")
                         .process(exchange -> {
                             String fileName = exchange.getIn().getHeader("AnalysisPayloadName", String.class);
-                            String downloadLink = exchange.getIn().getHeader("CamelAwsS3DownloadLink", String.class);
+                            String downloadLink = exchange.getIn().getHeader(S3Constants.DOWNLOAD_LINK, String.class);
 
                             PayloadDownloadLinkModel payloadDownloadLinkModel = new PayloadDownloadLinkModel(fileName, downloadLink);
                             exchange.getIn().setBody(payloadDownloadLinkModel);

--- a/src/main/resources/spring/camel-context.xml
+++ b/src/main/resources/spring/camel-context.xml
@@ -181,7 +181,9 @@
                     <choice>
                         <when>
                             <simple>${body} != null</simple>
+                            <setHeader headerName="${type:org.apache.camel.component.aws.s3.S3Constants.KEY}"><simple>${body.payloadStorageId}</simple></setHeader>
                             <bean ref="analysisService" method="deleteById(${header.id})" />
+                            <to uri="aws-s3:{{S3_BUCKET}}?amazonS3Client=#s3client&amp;operation=deleteObject" id="s3DeleteClient"/>
                             <setHeader headerName="Exchange.HTTP_RESPONSE_CODE">
                                 <simple resultType="String">${type:javax.servlet.http.HttpServletResponse.SC_NO_CONTENT}</simple>
                             </setHeader>

--- a/src/test/java/org/jboss/xavier/integrations/EndToEndTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/EndToEndTest.java
@@ -7,9 +7,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.AdviceWithRouteBuilder;
-import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.camel.test.spring.CamelSpringBootRunner;
 import org.apache.camel.test.spring.UseAdviceWith;
+import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.SoftAssertions;
@@ -64,6 +64,8 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.utility.MountableFile;
 
 import javax.inject.Inject;
+import javax.inject.Named;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -80,7 +82,6 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -149,6 +150,10 @@ public class EndToEndTest {
 
     @Value("${S3_BUCKET}")
     private String bucket;
+
+    @Inject
+    @Named("s3client")
+    private AmazonS3 storageClient;
 
     @Value("${server.port:8080}")
     private String serverPort;
@@ -383,13 +388,13 @@ public class EndToEndTest {
         FileUtils.deleteDirectory(new File("src/test/resources/insights-rbac"));
         FileUtils.deleteQuietly(new File("src/test/resources/insightsRbacRepo.zip"));
     }
-
-    private List<String> getS3Objects(String bucket) {
-        ListObjectsV2Request req = new ListObjectsV2Request().withBucketName(bucket).withMaxKeys(2);
-
-        return amazonS3.listObjectsV2(req).getObjectSummaries().stream().map(e -> e.getKey()).collect(Collectors.toList());
+    
+    private int getStorageObjectsSize() {
+        int s3Size = storageClient.listObjectsV2(new ListObjectsV2Request().withBucketName(bucket)).getKeyCount();
+        logger.info("S3 Objects : " + s3Size);
+        return s3Size;
     }
-
+    
     @Test
     public void end2endTest() throws Exception {
         Thread.sleep(2000);
@@ -397,14 +402,6 @@ public class EndToEndTest {
         // given
         camelContext.getGlobalOptions().put(Exchange.LOG_DEBUG_BODY_MAX_CHARS, "5000");
         camelContext.start();
-
-        camelContext.getRouteDefinition("store-in-s3").adviceWith(camelContext, new AdviceWithRouteBuilder() {
-            @Override
-            public void configure() {
-                weaveById("set-s3-key")
-                        .replace().process(e -> e.getIn().setHeader(S3Constants.KEY, "S3KEY123" + UUID.randomUUID().toString()));
-            }
-        });
 
         camelContext.getRouteDefinition("download-file").adviceWith(camelContext, new AdviceWithRouteBuilder() {
             @Override
@@ -431,6 +428,7 @@ public class EndToEndTest {
 
         // Start the camel route as if the UI was sending the file to the Camel Rest Upload route
         int analysisNum = 0;
+        assertThat(getStorageObjectsSize()).isEqualTo(0);
 
         logger.info("+++++++  Regular Test ++++++");
         analysisNum++;
@@ -447,8 +445,7 @@ public class EndToEndTest {
             });
 
         // Check S3
-        assertThat(getS3Objects(bucket).stream().allMatch(e -> e.startsWith("S3KEY123"))).isTrue();
-        assertThat(getS3Objects(bucket).size()).isEqualTo(1);
+        assertThat(getStorageObjectsSize()).isEqualTo(1);
 
         // Check DB for initialCostSavingsReport with concrete values
         InitialSavingsEstimationReportModel initialCostSavingsReportDB = initialSavingsEstimationReportService.findByAnalysisOwnerAndAnalysisId("dummy@redhat.com", 1L);
@@ -516,7 +513,6 @@ public class EndToEndTest {
                     softly.assertThat(wks_scanrunmodel_actual).isEqualTo(wks_scanrunmodel_expected);
                     softly.assertThat(wks_ostypemodel_actual).isEqualTo(wks_ostypemodel_expected);
         });
-
         // Performance test
         logger.info("+++++++  Performance Test ++++++");
 
@@ -625,6 +621,16 @@ public class EndToEndTest {
 
         int timeoutMilliseconds_secondSmallFile = timeoutMilliseconds_UltraPerformaceTest + timeoutMilliseconds_SmallFileSummaryReport;
         assertThat(callSummaryReportAndCheckVMs(String.format("/api/xavier/report/%d/workload-summary", analysisNum + 4), timeoutMilliseconds_secondSmallFile)).isEqualTo( 8);
+
+        // Testing the deletion of a file in S3
+        logger.info("++++++++ Delete report test +++++");
+        int s3ObjectsBefore = getStorageObjectsSize();
+
+        ResponseEntity<String> stringEntity = new RestTemplate().exchange("http://localhost:" + serverPort + String.format("/api/xavier/report/%d", 3), HttpMethod.DELETE, getRequestEntity(), new ParameterizedTypeReference<String>() {});
+        assertThat(stringEntity.getStatusCodeValue()).isEqualTo(HttpStatus.SC_NO_CONTENT);
+
+        assertThat(initialSavingsEstimationReportService.findByAnalysisOwnerAndAnalysisId("dummy@redhat.com", 3L)).isNull();
+        assertThat(getStorageObjectsSize()).isEqualTo(s3ObjectsBefore - 1);
 
         camelContext.stop();
     }

--- a/src/test/java/org/jboss/xavier/integrations/route/MainRouteBuilder_S3Test.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/MainRouteBuilder_S3Test.java
@@ -47,7 +47,7 @@ public class MainRouteBuilder_S3Test {
                 String uri = "aws-s3:xavier-dev?region=US_EAST_1&accessKey=accesskey&secretKey=RAW(secretkey)&fileName=" + keyValue + "&deleteAfterRead=false";
                 from(uri).routeId("s3route-consumer")
                         .process(e -> {
-                            String camelAwsS3ContentDisposition = e.getIn().getHeader("CamelAwsS3ContentDisposition", String.class);
+                            String camelAwsS3ContentDisposition = e.getIn().getHeader(S3Constants.CONTENT_DISPOSITION, String.class);
                             String filename = camelAwsS3ContentDisposition.substring(camelAwsS3ContentDisposition.indexOf("filename=") + 10, camelAwsS3ContentDisposition.length() - 1);
                             e.getIn().setHeader("filename", filename );
                         })

--- a/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
+++ b/src/test/java/org/jboss/xavier/integrations/route/XmlRoutes_RestReportTest.java
@@ -2,6 +2,7 @@ package org.jboss.xavier.integrations.route;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.component.aws.s3.S3Constants;
 import org.apache.commons.io.IOUtils;
 import org.jboss.xavier.Application;
 import org.jboss.xavier.analytics.pojo.output.AnalysisModel;
@@ -489,6 +490,13 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
         Long one = 1L;
         when(analysisService.findByOwnerAndId("mrizzi@redhat.com",one)).thenReturn(new AnalysisModel());
         doNothing().when(analysisService).deleteById(one);
+        
+        camelContext.getRouteDefinition("report-delete").adviceWith(camelContext, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() {
+                weaveById("s3DeleteClient").remove();
+            }
+        });
 
         //When
         camelContext.start();
@@ -1118,8 +1126,8 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
                 public void configure() throws Exception {
                     weaveById("pollEnrich").replace()
                             .setHeader(Exchange.HTTP_RESPONSE_CODE, simple("200"))
-                            .setHeader("CamelAwsS3ContentDisposition", constant("attachment; filename=\"cloudforms-export-v1_0_0.json\""))
-                            .setHeader("CamelAwsS3ContentType", constant("application/octet-stream"))
+                            .setHeader(S3Constants.CONTENT_DISPOSITION, constant("attachment; filename=\"cloudforms-export-v1_0_0.json\""))
+                            .setHeader(S3Constants.CONTENT_TYPE, constant("application/octet-stream"))
                             .setBody(exchange -> this.getClass().getClassLoader().getResourceAsStream("cloudforms-export-v1_0_0.json"));
                 }
             });
@@ -1156,7 +1164,7 @@ public class XmlRoutes_RestReportTest extends XavierCamelTest {
             @Override
             public void configure() throws Exception {
                 weaveById("aws-s3-get-download-link").replace()
-                        .setHeader("CamelAwsS3DownloadLink", constant("https://myDownloadLink.s3.com"));
+                        .setHeader(S3Constants.DOWNLOAD_LINK, constant("https://myDownloadLink.s3.com"));
             }
         });
 


### PR DESCRIPTION
…… (#103)

* MIGENG-449 added the delete action of the S3 file and the test in End2EndTest

* MIGENG-449 fixed URL for the delete test

* MIGENG-449 changed the way to pass the File KEY to S3
change expected status code on the test

* MIGENG-449 added arg to travis pipeline to reduce logging
removed the replacement for the S3 object key

* MIGENG-449 removed s3 component on the Delete unit test to not modify the http response code

* MIGENG-449 Added service to retrieve objects in S3
added call to get number of objects in S3 after upload and after delete
refactored hard coded constants to use proper constants

* MIGENG-449 rollback changes to retrieve S3 number of objects as AWS only gives up to 1000, will do with command line to check

* MIGENG-449 deleted unused class StorageService

* MIGENG-449 removed old code